### PR TITLE
8346688: GenShen: Missing metadata trigger log message

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahRegulatorThread.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahRegulatorThread.cpp
@@ -64,7 +64,8 @@ void ShenandoahRegulatorThread::regulate_young_and_old_cycles() {
     if (mode == ShenandoahGenerationalControlThread::none) {
       if (should_start_metaspace_gc()) {
         if (request_concurrent_gc(GLOBAL)) {
-          log_debug(gc)("Heuristics request for global (unload classes) accepted.");
+          // Some of vmTestbase/metaspace tests depend on following line to count GC cycles
+          _global_heuristics->log_trigger("%s", GCCause::to_string(GCCause::_metadata_GC_threshold));
         }
       } else {
         if (_young_heuristics->should_start_gc()) {


### PR DESCRIPTION
Clean backport. Fixes 3 vmTestbase metaspace tests.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8346688](https://bugs.openjdk.org/browse/JDK-8346688) needs maintainer approval

### Issue
 * [JDK-8346688](https://bugs.openjdk.org/browse/JDK-8346688): GenShen: Missing metadata trigger log message (**Task** - P4 - Approved)


### Reviewers
 * [Y. Srinivas Ramakrishna](https://openjdk.org/census#ysr) (@ysramakrishna - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk24u.git pull/5/head:pull/5` \
`$ git checkout pull/5`

Update a local copy of the PR: \
`$ git checkout pull/5` \
`$ git pull https://git.openjdk.org/jdk24u.git pull/5/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5`

View PR using the GUI difftool: \
`$ git pr show -t 5`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk24u/pull/5.diff">https://git.openjdk.org/jdk24u/pull/5.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk24u/pull/5#issuecomment-2557512081)
</details>
