### PR TITLE
8346713: [testsuite] NeverActAsServerClassMachine breaks TestPLABAdaptToMinTLABSize.java TestPinnedHumongousFragmentation.java TestPinnedObjectContents.java

### DIFF
--- a/test/hotspot/jtreg/gc/TestPLABAdaptToMinTLABSize.java
+++ b/test/hotspot/jtreg/gc/TestPLABAdaptToMinTLABSize.java
@@ -24,17 +24,29 @@
 package gc;
 
 /*
- * @test TestPLABAdaptToMinTLABSize
+ * @test TestPLABAdaptToMinTLABSizeG1
  * @bug 8289137
  * @summary Make sure that Young/OldPLABSize adapt to MinTLABSize setting.
- * @requires vm.gc.Parallel | vm.gc.G1
+ * @requires vm.gc.G1
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.management
- * @run driver gc.TestPLABAdaptToMinTLABSize
+ * @run driver gc.TestPLABAdaptToMinTLABSize -XX:+UseG1GC
+ */
+
+/*
+ * @test TestPLABAdaptToMinTLABSizeParallel
+ * @bug 8289137
+ * @summary Make sure that Young/OldPLABSize adapt to MinTLABSize setting.
+ * @requires vm.gc.Parallel
+ * @library /test/lib
+ * @modules java.base/jdk.internal.misc
+ *          java.management
+ * @run driver gc.TestPLABAdaptToMinTLABSize -XX:+UseParallelGC
  */
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 
 import jdk.test.lib.process.OutputAnalyzer;
@@ -68,9 +80,10 @@ public class TestPLABAdaptToMinTLABSize {
     }
 
     public static void main(String[] args) throws Exception {
-        runTest(true, "-XX:MinTLABSize=100k");
+        String gc = args[0];
+        runTest(true, gc, "-XX:MinTLABSize=100k");
         // Should not succeed when explicitly specifying invalid combination.
-        runTest(false, "-XX:MinTLABSize=100k", "-XX:OldPLABSize=5k");
-        runTest(false, "-XX:MinTLABSize=100k", "-XX:YoungPLABSize=5k");
+        runTest(false, gc, "-XX:MinTLABSize=100k", "-XX:OldPLABSize=5k");
+        runTest(false, gc, "-XX:MinTLABSize=100k", "-XX:YoungPLABSize=5k");
     }
 }

--- a/test/hotspot/jtreg/gc/g1/pinnedobjs/TestPinnedHumongousFragmentation.java
+++ b/test/hotspot/jtreg/gc/g1/pinnedobjs/TestPinnedHumongousFragmentation.java
@@ -36,7 +36,7 @@
  * @build jdk.test.whitebox.WhiteBox
  * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
  * @run main/othervm -Xlog:gc+region=trace -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions -Xmx1g -Xms1g
- *      -XX:VerifyGCType=full -XX:+VerifyDuringGC -XX:+VerifyAfterGC -XX:+WhiteBoxAPI -Xbootclasspath/a:.
+ *      -XX:VerifyGCType=full -XX:+VerifyDuringGC -XX:+VerifyAfterGC -XX:+WhiteBoxAPI -XX:+UseG1GC -Xbootclasspath/a:.
  *      gc.g1.pinnedobjs.TestPinnedHumongousFragmentation
  */
 

--- a/test/hotspot/jtreg/gc/g1/pinnedobjs/TestPinnedObjectContents.java
+++ b/test/hotspot/jtreg/gc/g1/pinnedobjs/TestPinnedObjectContents.java
@@ -33,7 +33,8 @@
  *          java.management
  * @build jdk.test.whitebox.WhiteBox
  * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
- * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xbootclasspath/a:. -XX:+ZapUnusedHeapArea -Xlog:gc,gc+ergo+cset=trace gc.g1.pinnedobjs.TestPinnedObjectContents
+ * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -XX:+UseG1GC
+ *      -Xbootclasspath/a:. -XX:+ZapUnusedHeapArea -Xlog:gc,gc+ergo+cset=trace gc.g1.pinnedobjs.TestPinnedObjectContents
  */
 
 package gc.g1.pinnedobjs;


### PR DESCRIPTION
A clean backport.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8346713](https://bugs.openjdk.org/browse/JDK-8346713) needs maintainer approval

### Issue
 * [JDK-8346713](https://bugs.openjdk.org/browse/JDK-8346713): [testsuite] NeverActAsServerClassMachine breaks TestPLABAdaptToMinTLABSize.java TestPinnedHumongousFragmentation.java TestPinnedObjectContents.java (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk24u.git pull/8/head:pull/8` \
`$ git checkout pull/8`

Update a local copy of the PR: \
`$ git checkout pull/8` \
`$ git pull https://git.openjdk.org/jdk24u.git pull/8/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8`

View PR using the GUI difftool: \
`$ git pr show -t 8`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk24u/pull/8.diff">https://git.openjdk.org/jdk24u/pull/8.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk24u/pull/8#issuecomment-2557988218)
</details>
