### PR TITLE
8343224: print/Dialog/PaperSizeError.java fails with MediaSizeName is not A4: A4

### DIFF
--- a/src/java.desktop/share/classes/sun/print/CustomMediaSizeName.java
+++ b/src/java.desktop/share/classes/sun/print/CustomMediaSizeName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -203,16 +203,17 @@ class CustomMediaSizeName extends MediaSizeName {
         if (value == null) {
             value = new CustomMediaSizeName(name, choice, width, length);
             customMap.put(key, value);
-
-            // add this new custom media size name to MediaSize array
-            if ((width > 0.0) && (length > 0.0)) {
-                try {
-                    new MediaSize(width, length, Size2DSyntax.INCH, value);
-                } catch (IllegalArgumentException e) {
+            if (value.getStandardMedia() == null) {
+                // add this new custom media size name to MediaSize array
+                if ((width > 0.0) && (length > 0.0)) {
+                    try {
+                        new MediaSize(width, length, Size2DSyntax.INCH, value);
+                    } catch (IllegalArgumentException e) {
                         /* PDF printer in Linux for Ledger paper causes
                         "IllegalArgumentException: X dimension > Y dimension".
                         We rotate based on IPP spec. */
-                    new MediaSize(length, width, Size2DSyntax.INCH, value);
+                        new MediaSize(length, width, Size2DSyntax.INCH, value);
+                    }
                 }
             }
         }

--- a/test/jdk/java/awt/print/Dialog/PaperSizeError.java
+++ b/test/jdk/java/awt/print/Dialog/PaperSizeError.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,16 +23,22 @@
 
 /**
  * @test
- * @bug 6360339
+ * @bug 6360339 8343224
  * @key printer
  * @summary Test for fp error in paper size calculations.
  * @run main/manual PaperSizeError
  */
 
-import java.awt.print.*;
-import javax.print.*;
-import javax.print.attribute.*;
-import javax.print.attribute.standard.*;
+import javax.print.PrintService;
+import javax.print.attribute.HashPrintRequestAttributeSet;
+import javax.print.attribute.PrintRequestAttributeSet;
+import javax.print.attribute.Size2DSyntax;
+import javax.print.attribute.standard.MediaSize;
+import javax.print.attribute.standard.MediaSizeName;
+import javax.print.attribute.standard.OrientationRequested;
+import java.awt.print.PageFormat;
+import java.awt.print.Paper;
+import java.awt.print.PrinterJob;
 
 public class PaperSizeError {
 


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [b3e63631](https://github.com/openjdk/jdk/commit/b3e63631c735862ba00270636b4ef51c0e48a1af) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by GennadiyKrivoshein on 28 Dec 2024 and was reviewed by Alexander Zvegintsev, Alexander Scherbatiy, Prasanta Sadhukhan and Alisen Chung.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8343224](https://bugs.openjdk.org/browse/JDK-8343224) needs maintainer approval

### Issue
 * [JDK-8343224](https://bugs.openjdk.org/browse/JDK-8343224): print/Dialog/PaperSizeError.java fails with MediaSizeName is not A4: A4 (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk24u.git pull/11/head:pull/11` \
`$ git checkout pull/11`

Update a local copy of the PR: \
`$ git checkout pull/11` \
`$ git pull https://git.openjdk.org/jdk24u.git pull/11/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11`

View PR using the GUI difftool: \
`$ git pr show -t 11`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk24u/pull/11.diff">https://git.openjdk.org/jdk24u/pull/11.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk24u/pull/11#issuecomment-2620331425)
</details>
