### PR TITLE
Backport 3f7052ed7af89efd1c6977df0b4f3b95fcfec764

### DIFF
--- a/src/hotspot/cpu/riscv/codeBuffer_riscv.hpp
+++ b/src/hotspot/cpu/riscv/codeBuffer_riscv.hpp
@@ -33,6 +33,6 @@ private:
 
 public:
   void flush_bundle(bool start_new_bundle) {}
-  static bool supports_shared_stubs() { return false; }
+  static bool supports_shared_stubs() { return true; }
 
 #endif // CPU_RISCV_CODEBUFFER_RISCV_HPP

--- a/test/hotspot/jtreg/compiler/sharedstubs/SharedTrampolineTest.java
+++ b/test/hotspot/jtreg/compiler/sharedstubs/SharedTrampolineTest.java
@@ -30,7 +30,7 @@
  *
  * @requires vm.compiler2.enabled
  * @requires vm.opt.TieredCompilation == null
- * @requires os.arch=="aarch64" | os.arch=="riscv64"
+ * @requires os.arch=="aarch64"
  * @requires vm.debug
  *
  * @run driver compiler.sharedstubs.SharedTrampolineTest -XX:-TieredCompilation


### PR DESCRIPTION
Hi all,

Same issue is there in jdk24u repo.

This pull request contains a backport of commit [3f7052ed](https://github.com/openjdk/jdk/commit/3f7052ed7af89efd1c6977df0b4f3b95fcfec764) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Fei Yang on 7 Jan 2025 and was reviewed by Robbin Ehn and Hamlin Li.

Thanks!