### PR TITLE
8347124: Clean tests with --enable-linkable-runtime

### DIFF
--- a/test/jdk/jdk/jfr/jvm/TestModularImage.java
+++ b/test/jdk/jdk/jfr/jvm/TestModularImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -43,7 +43,12 @@ import jdk.test.lib.process.ProcessTools;
  *          as expected
  * @requires vm.hasJFR
  * @library /test/lib
- * @run driver jdk.jfr.jvm.TestModularImage
+ * @comment Test is being run in othervm to support JEP 493 enabled
+ *          JDKs which don't allow patched modules. Note that jtreg patches
+ *          module java.base to add java.lang.JTRegModuleHelper. If then a
+ *          jlink run is attempted in-process - using the ToolProvider API -
+ *          on a JEP 493 enabled JDK, the test fails.
+ * @run main/othervm jdk.jfr.jvm.TestModularImage
  */
 public class TestModularImage {
     private static final String STARTED_RECORDING = "Started recording";

--- a/test/jdk/tools/launcher/SourceMode.java
+++ b/test/jdk/tools/launcher/SourceMode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,12 @@
  * @bug 8192920 8204588 8210275 8286571
  * @summary Test source mode
  * @modules jdk.compiler jdk.jlink
- * @run main SourceMode
+ * @comment Test is being run in othervm to support JEP 493 enabled
+ *          JDKs which don't allow patched modules. Note that jtreg patches
+ *          module java.base to add java.lang.JTRegModuleHelper. If then a
+ *          jlink run is attempted in-process - using the ToolProvider API -
+ *          on a JEP 493 enabled JDK, the test fails.
+ * @run main/othervm SourceMode
  */
 
 


### PR DESCRIPTION
Clean backport of some test fixes which make JEP 493 enabled builds pass those tests. I'll follow-up with https://bugs.openjdk.org/browse/JDK-8347496 (once this is in).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8347124](https://bugs.openjdk.org/browse/JDK-8347124) needs maintainer approval

### Issue
 * [JDK-8347124](https://bugs.openjdk.org/browse/JDK-8347124): Clean tests with --enable-linkable-runtime (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk24u.git pull/18/head:pull/18` \
`$ git checkout pull/18`

Update a local copy of the PR: \
`$ git checkout pull/18` \
`$ git pull https://git.openjdk.org/jdk24u.git pull/18/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18`

View PR using the GUI difftool: \
`$ git pr show -t 18`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk24u/pull/18.diff">https://git.openjdk.org/jdk24u/pull/18.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk24u/pull/18#issuecomment-2589520494)
</details>
