### PR TITLE
8347039: ThreadPerTaskExecutor terminates if cancelled tasks still running

### DIFF
--- a/src/java.base/share/classes/java/util/concurrent/ThreadPerTaskExecutor.java
+++ b/src/java.base/share/classes/java/util/concurrent/ThreadPerTaskExecutor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -318,8 +318,12 @@ class ThreadPerTaskExecutor extends ThreadContainer implements ExecutorService {
         }
 
         @Override
-        protected void done() {
-            executor.taskComplete(thread);
+        public void run() {
+            try {
+                super.run();
+            } finally {
+                executor.taskComplete(thread);
+            }
         }
     }
 


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [af3f5d85](https://github.com/openjdk/jdk/commit/af3f5d852e5dd0191548bdc477546b5b343d1276) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Alan Bateman on 15 Jan 2025 and was reviewed by Viktor Klang.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] [JDK-8347039](https://bugs.openjdk.org/browse/JDK-8347039) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8347039](https://bugs.openjdk.org/browse/JDK-8347039): ThreadPerTaskExecutor terminates if cancelled tasks still running (**Bug** - P3 - Rejected)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk24u.git pull/19/head:pull/19` \
`$ git checkout pull/19`

Update a local copy of the PR: \
`$ git checkout pull/19` \
`$ git pull https://git.openjdk.org/jdk24u.git pull/19/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19`

View PR using the GUI difftool: \
`$ git pr show -t 19`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk24u/pull/19.diff">https://git.openjdk.org/jdk24u/pull/19.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk24u/pull/19#issuecomment-2592829870)
</details>
