### PR TITLE
8345614: Improve AnnotationFormatError message for duplicate annotation interfaces

### DIFF
--- a/src/java.base/share/classes/sun/reflect/annotation/AnnotationParser.java
+++ b/src/java.base/share/classes/sun/reflect/annotation/AnnotationParser.java
@@ -123,7 +123,7 @@ public class AnnotationParser {
                 if (AnnotationType.getInstance(klass).retention() == RetentionPolicy.RUNTIME &&
                     result.put(klass, a) != null) {
                         throw new AnnotationFormatError(
-                            "Duplicate annotation for class: "+klass+": " + a);
+                            "Duplicate annotation " + klass + " in " + container);
             }
         }
         }


### PR DESCRIPTION
Please review this backport, that updates the error message when two annotations in a location has the same annotation interface to include the class file name where this happens in addition to the name of the interface.

This is backported to 24.0.1 or later instead of 24 because this is not eligible for RDP 1 or 2.

This pull request contains a backport of commit [7aa0cbc9](https://github.com/openjdk/jdk/commit/7aa0cbc91d90493a3dae973cb8077cfa283c32b4) from openjdk/jdk#22581.

The commit being backported was authored by Scott Marlow on 9 Dec 2024 and was reviewed by Chen Liang.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8345614](https://bugs.openjdk.org/browse/JDK-8345614) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8345614](https://bugs.openjdk.org/browse/JDK-8345614): Improve AnnotationFormatError message for duplicate annotation interfaces (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk24u.git pull/20/head:pull/20` \
`$ git checkout pull/20`

Update a local copy of the PR: \
`$ git checkout pull/20` \
`$ git pull https://git.openjdk.org/jdk24u.git pull/20/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20`

View PR using the GUI difftool: \
`$ git pr show -t 20`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk24u/pull/20.diff">https://git.openjdk.org/jdk24u/pull/20.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk24u/pull/20#issuecomment-2594436123)
</details>
