### PR TITLE
Backport 3967696386ecc706927f05dfae0841b3f23e319d

### DIFF
--- a/test/jdk/jdk/jfr/jvm/TestModularImage.java
+++ b/test/jdk/jdk/jfr/jvm/TestModularImage.java
@@ -43,6 +43,7 @@ import jdk.test.lib.process.ProcessTools;
  *          as expected
  * @requires vm.hasJFR
  * @library /test/lib
+ * @modules jdk.compiler jdk.jlink
  * @comment Test is being run in othervm to support JEP 493 enabled
  *          JDKs which don't allow patched modules. Note that jtreg patches
  *          module java.base to add java.lang.JTRegModuleHelper. If then a


### PR DESCRIPTION
Clean backport of a test-only change required for clean tests in some environments. Follow-up to https://bugs.openjdk.org/browse/JDK-8347124 which got backported to 24.0.1