### PR TITLE
8347256: Epsilon: Demote heap size and AlwaysPreTouch warnings to info level

### DIFF
--- a/src/hotspot/share/gc/epsilon/epsilonInitLogger.cpp
+++ b/src/hotspot/share/gc/epsilon/epsilonInitLogger.cpp
@@ -32,18 +32,6 @@
 #include "utilities/globalDefinitions.hpp"
 
 void EpsilonInitLogger::print_gc_specific() {
-  // Warn users that non-resizable heap might be better for some configurations.
-  // We are not adjusting the heap size by ourselves, because it affects startup time.
-  if (InitialHeapSize != MaxHeapSize) {
-    log_warning(gc, init)("Consider setting -Xms equal to -Xmx to avoid resizing hiccups");
-  }
-
-  // Warn users that AlwaysPreTouch might be better for some configurations.
-  // We are not turning this on by ourselves, because it affects startup time.
-  if (FLAG_IS_DEFAULT(AlwaysPreTouch) && !AlwaysPreTouch) {
-    log_warning(gc, init)("Consider enabling -XX:+AlwaysPreTouch to avoid memory commit hiccups");
-  }
-
   if (UseTLAB) {
     size_t max_tlab = EpsilonHeap::heap()->max_tlab_size() * HeapWordSize;
     log_info(gc, init)("TLAB Size Max: " SIZE_FORMAT "%s",
@@ -56,6 +44,18 @@ void EpsilonInitLogger::print_gc_specific() {
     }
   } else {
     log_info(gc, init)("TLAB: Disabled");
+  }
+
+  // Suggest that non-resizable heap might be better for some configurations.
+  // We are not adjusting the heap size by ourselves, because it affects startup time.
+  if (InitialHeapSize != MaxHeapSize) {
+    log_info(gc)("Consider setting -Xms equal to -Xmx to avoid resizing hiccups");
+  }
+
+  // Suggest that AlwaysPreTouch might be better for some configurations.
+  // We are not turning this on by ourselves, because it affects startup time.
+  if (FLAG_IS_DEFAULT(AlwaysPreTouch) && !AlwaysPreTouch) {
+    log_info(gc)("Consider enabling -XX:+AlwaysPreTouch to avoid memory commit hiccups");
   }
 }
 


### PR DESCRIPTION
UX improvement for Epsilon. The patch is simple and was in mainline for a few weeks.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8347256](https://bugs.openjdk.org/browse/JDK-8347256) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8347256](https://bugs.openjdk.org/browse/JDK-8347256): Epsilon: Demote heap size and AlwaysPreTouch warnings to info level (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk24u.git pull/25/head:pull/25` \
`$ git checkout pull/25`

Update a local copy of the PR: \
`$ git checkout pull/25` \
`$ git pull https://git.openjdk.org/jdk24u.git pull/25/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25`

View PR using the GUI difftool: \
`$ git pr show -t 25`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk24u/pull/25.diff">https://git.openjdk.org/jdk24u/pull/25.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk24u/pull/25#issuecomment-2604939804)
</details>
