### PR TITLE
8290043: serviceability/attach/ConcAttachTest.java failed "guarantee(!CheckJNICalls) failed: Attached JNI thread exited without being detached"

### DIFF
--- a/src/hotspot/share/runtime/javaThread.cpp
+++ b/src/hotspot/share/runtime/javaThread.cpp
@@ -1050,7 +1050,6 @@ void JavaThread::cleanup_failed_attach_current_thread(bool is_daemon) {
   }
 
   Threads::remove(this, is_daemon);
-  this->smr_delete();
 }
 
 JavaThread* JavaThread::active() {

--- a/src/hotspot/share/runtime/thread.cpp
+++ b/src/hotspot/share/runtime/thread.cpp
@@ -247,6 +247,9 @@ void Thread::call_run() {
   // asynchronously with respect to its termination - that is what _run_state can
   // be used to check.
 
+  // Logically we should do this->unregister_thread_stack_with_NMT() here, but we
+  // had to move that into post_run() because of the `this` deletion issue.
+
   assert(Thread::current_or_null() == nullptr, "current thread still present");
 }
 

--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2016, 2024, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2016, 2025, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -149,8 +149,6 @@ serviceability/sa/ClhsdbPmap.java#core            8267433,8318754 macosx-x64,mac
 serviceability/sa/ClhsdbPstack.java#core          8267433,8318754 macosx-x64,macosx-aarch64
 serviceability/sa/TestJmapCore.java               8267433,8318754 macosx-x64,macosx-aarch64
 serviceability/sa/TestJmapCoreMetaspace.java      8267433,8318754 macosx-x64,macosx-aarch64
-
-serviceability/attach/ConcAttachTest.java 8290043 linux-all
 
 serviceability/jvmti/stress/StackTrace/NotSuspended/GetStackTraceNotSuspendedStressTest.java 8315980 linux-all,windows-x64
 

--- a/test/hotspot/jtreg/runtime/jni/terminatedThread/TestTerminatedThread.java
+++ b/test/hotspot/jtreg/runtime/jni/terminatedThread/TestTerminatedThread.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,8 +32,10 @@ import java.lang.management.*;
  * @library /testlibrary
  * @summary Basic test of Thread and ThreadMXBean queries on a natively
  *          attached thread that has failed to detach before terminating.
- * @comment The native code only supports POSIX so no windows testing
- * @run main/othervm/native TestTerminatedThread
+ * @comment The native code only supports POSIX so no windows testing.
+ * @comment Disable -Xcheck:jni else NMT can report a fatal error because
+ *          we did not detach before exiting.
+ * @run main/othervm/native -XX:-CheckJNICalls TestTerminatedThread
  */
 
 import jvmti.JVMTIUtils;


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [9b1bed0a](https://github.com/openjdk/jdk/commit/9b1bed0aa416c615a81d429e2f1f33bc4f679109) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by David Holmes on 14 Jan 2025 and was reviewed by Johan Sjölen and Coleen Phillimore.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8290043](https://bugs.openjdk.org/browse/JDK-8290043) needs maintainer approval

### Issue
 * [JDK-8290043](https://bugs.openjdk.org/browse/JDK-8290043): serviceability/attach/ConcAttachTest.java failed "guarantee(!CheckJNICalls) failed: Attached JNI thread exited without being detached" (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk24u.git pull/26/head:pull/26` \
`$ git checkout pull/26`

Update a local copy of the PR: \
`$ git checkout pull/26` \
`$ git pull https://git.openjdk.org/jdk24u.git pull/26/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26`

View PR using the GUI difftool: \
`$ git pr show -t 26`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk24u/pull/26.diff">https://git.openjdk.org/jdk24u/pull/26.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk24u/pull/26#issuecomment-2606157285)
</details>
