### PR TITLE
Backport f67b703625afa2e049c572978d29ac00d8c956d3

### DIFF
--- a/test/jdk/javax/swing/JTabbedPane/8134116/Bug8134116.java
+++ b/test/jdk/javax/swing/JTabbedPane/8134116/Bug8134116.java
@@ -1,13 +1,43 @@
+/*
+ * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
 
-import java.awt.*;
+import java.awt.Component;
+import java.awt.Rectangle;
 import java.awt.event.KeyEvent;
 import java.util.ArrayList;
 import java.util.List;
+
 import javax.accessibility.Accessible;
 import javax.accessibility.AccessibleContext;
 import javax.accessibility.AccessibleState;
 import javax.accessibility.AccessibleStateSet;
-import javax.swing.*;
+import javax.swing.Icon;
+import javax.swing.JFrame;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.JTabbedPane;
+import javax.swing.SwingUtilities;
+import javax.swing.UIManager;
 import javax.swing.plaf.nimbus.NimbusLookAndFeel;
 
 /*
@@ -22,7 +52,7 @@ public class Bug8134116 {
     private static volatile Exception exception = null;
     private static JFrame frame;
 
-    public static void main(String args[]) throws Exception {
+    public static void main(String[] args) throws Exception {
 
         try {
             UIManager.setLookAndFeel(new NimbusLookAndFeel());


### PR DESCRIPTION
Add the missing GPL header to `test/jdk/javax/swing/JTabbedPane/8134116/Bug8134116.java`.

> This pull request contains a backport of commit [f67b7036](https://github.com/openjdk/jdk/commit/f67b703625afa2e049c572978d29ac00d8c956d3) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.
>
> The commit being backported was authored by Alexey Ivanov on 13 Jan 2025 and was reviewed by Dmitry Markov, Harshitha Onkar and Abhishek Kumar.