### PR TITLE
8348562: ZGC: segmentation fault due to missing node type check in barrier elision analysis

### DIFF
--- a/src/hotspot/share/gc/z/c2/zBarrierSetC2.cpp
+++ b/src/hotspot/share/gc/z/c2/zBarrierSetC2.cpp
@@ -559,7 +559,9 @@ static const Node* get_base_and_offset(const MachNode* mach, intptr_t& offset) {
     // The memory address is computed by 'base' and fed to 'mach' via an
     // indirect memory operand (indicated by offset == 0). The ultimate base and
     // offset can be fetched directly from the inputs and Ideal type of 'base'.
-    offset = base->bottom_type()->isa_oopptr()->offset();
+    const TypeOopPtr* oopptr = base->bottom_type()->isa_oopptr();
+    if (oopptr == nullptr) return nullptr;
+    offset = oopptr->offset();
     // Even if 'base' is not an Ideal AddP node anymore, Matcher::ReduceInst()
     // guarantees that the base address is still available at the same slot.
     base = base->in(AddPNode::Base);


### PR DESCRIPTION
Clean backport of [JDK-8348562](https://bugs.openjdk.org/browse/JDK-8348562). It only adds a null check + bailout where the current implementation crashes with SIGSEGV.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8348562](https://bugs.openjdk.org/browse/JDK-8348562) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8348562](https://bugs.openjdk.org/browse/JDK-8348562): ZGC: segmentation fault due to missing node type check in barrier elision analysis (**Bug** - P2 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk24u.git pull/35/head:pull/35` \
`$ git checkout pull/35`

Update a local copy of the PR: \
`$ git checkout pull/35` \
`$ git pull https://git.openjdk.org/jdk24u.git pull/35/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 35`

View PR using the GUI difftool: \
`$ git pr show -t 35`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk24u/pull/35.diff">https://git.openjdk.org/jdk24u/pull/35.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk24u/pull/35#issuecomment-2615374317)
</details>
