### PR TITLE
8345185: Update jpackage to not include service bindings by default

### DIFF
--- a/src/jdk.jpackage/share/classes/jdk/jpackage/internal/JLinkBundlerHelper.java
+++ b/src/jdk.jpackage/share/classes/jdk/jpackage/internal/JLinkBundlerHelper.java
@@ -47,6 +47,7 @@ import java.util.regex.Matcher;
 import java.util.spi.ToolProvider;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+
 import jdk.internal.module.ModulePath;
 
 
@@ -99,8 +100,10 @@ final class JLinkBundlerHelper {
 
         ModuleFinder finder = createModuleFinder(paths);
 
+        // Don't perform service bindings by default as outlined by JEP 343
+        // and JEP 392
         return Configuration.empty()
-                .resolveAndBind(finder, ModuleFinder.of(), roots)
+                .resolve(finder, ModuleFinder.of(), roots)
                 .modules()
                 .stream()
                 .map(ResolvedModule::name)

--- a/test/jdk/tools/jpackage/TEST.properties
+++ b/test/jdk/tools/jpackage/TEST.properties
@@ -14,4 +14,5 @@ exclusiveAccess.dirs=share windows
 modules=jdk.jpackage/jdk.jpackage.internal:+open \
         jdk.jpackage/jdk.jpackage.internal.util \
         jdk.jpackage/jdk.jpackage.internal.util.function \
-        java.base/jdk.internal.util
+        java.base/jdk.internal.util \
+        jdk.jlink/jdk.tools.jlink.internal

--- a/test/jdk/tools/jpackage/share/JLinkOptionsTest.java
+++ b/test/jdk/tools/jpackage/share/JLinkOptionsTest.java
@@ -58,24 +58,26 @@ public final class JLinkOptionsTest {
                     "--jlink-options",
                     "--strip-debug --no-man-pages --no-header-files",
                     "--jlink-options",
-                    "--bind-services",
+                    "--verbose --bind-services --limit-modules java.smartcardio,jdk.crypto.cryptoki,java.desktop",
                     },
-                    // with bind-services should have some services
+                    // with limit-modules and bind-services should have them in the result
                     new String[]{"java.smartcardio", "jdk.crypto.cryptoki"},
                     null,
                     },
             // bind-services
             {"Hello", new String[]{
-                    "--jlink-options", "--bind-services",
+                    "--jlink-options",
+                    "--bind-services --limit-modules jdk.jartool,jdk.unsupported,java.desktop",
                     },
-                    // non modular should have everything
+                    // non modular should have at least the module limits
                     new String[]{"jdk.jartool", "jdk.unsupported"},
                     null,
                     },
 
             // jlink-options --bind-services
             {"com.other/com.other.Hello", new String[]{
-                    "--jlink-options", "--bind-services",
+                    "--jlink-options",
+                    "--bind-services --limit-modules java.smartcardio,jdk.crypto.cryptoki,java.desktop",
                     },
                     // with bind-services should have some services
                     new String[]{"java.smartcardio", "jdk.crypto.cryptoki"},

--- a/test/jdk/tools/jpackage/share/RuntimeImageSymbolicLinksTest.java
+++ b/test/jdk/tools/jpackage/share/RuntimeImageSymbolicLinksTest.java
@@ -51,7 +51,6 @@ public class RuntimeImageSymbolicLinksTest {
 
     @Test
     public static void test() throws Exception {
-        final Path jmods = Path.of(System.getProperty("java.home"), "jmods");
         final Path workDir = TKit.createTempDirectory("runtime").resolve("data");
         final Path jlinkOutputDir = workDir.resolve("temp.runtime");
         Files.createDirectories(jlinkOutputDir.getParent());
@@ -61,8 +60,7 @@ public class RuntimeImageSymbolicLinksTest {
         .dumpOutput()
         .addArguments(
                 "--output", jlinkOutputDir.toString(),
-                "--add-modules", "ALL-MODULE-PATH",
-                "--module-path", jmods.toString(),
+                "--add-modules", "java.desktop",
                 "--strip-debug",
                 "--no-header-files",
                 "--no-man-pages",

--- a/test/jdk/tools/jpackage/share/RuntimeImageTest.java
+++ b/test/jdk/tools/jpackage/share/RuntimeImageTest.java
@@ -44,7 +44,6 @@ public class RuntimeImageTest {
 
     @Test
     public static void test() throws Exception {
-        final Path jmods = Path.of(System.getProperty("java.home"), "jmods");
         final Path workDir = TKit.createTempDirectory("runtime").resolve("data");
         final Path jlinkOutputDir = workDir.resolve("temp.runtime");
         Files.createDirectories(jlinkOutputDir.getParent());
@@ -54,8 +53,7 @@ public class RuntimeImageTest {
         .dumpOutput()
         .addArguments(
                 "--output", jlinkOutputDir.toString(),
-                "--add-modules", "ALL-MODULE-PATH",
-                "--module-path", jmods.toString(),
+                "--add-modules", "java.desktop",
                 "--strip-debug",
                 "--no-header-files",
                 "--no-man-pages",

--- a/test/jdk/tools/jpackage/share/RuntimePackageTest.java
+++ b/test/jdk/tools/jpackage/share/RuntimePackageTest.java
@@ -101,7 +101,6 @@ public class RuntimePackageTest {
         .forTypes(types)
         .addInitializer(cmd -> {
             final Path runtimeImageDir;
-            final Path jmods = Path.of(System.getProperty("java.home"), "jmods");
 
             if (JPackageCommand.DEFAULT_RUNTIME_IMAGE != null) {
                 runtimeImageDir = JPackageCommand.DEFAULT_RUNTIME_IMAGE;
@@ -113,8 +112,7 @@ public class RuntimePackageTest {
                 .dumpOutput()
                 .addArguments(
                         "--output", runtimeImageDir.toString(),
-                        "--add-modules", "ALL-MODULE-PATH",
-                        "--module-path", jmods.toString(),
+                        "--add-modules", "java.desktop",
                         "--strip-debug",
                         "--no-header-files",
                         "--no-man-pages")


### PR DESCRIPTION
Clean backport of JDK-8345185, which would be great to have in 24.0.1 as well since that improves usability of `jpackage` in combination with `JEP 493` enabled builds of JDK 24.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8345185](https://bugs.openjdk.org/browse/JDK-8345185) needs maintainer approval
- [x] Change requires CSR request [JDK-8346379](https://bugs.openjdk.org/browse/JDK-8346379) to be approved

### Issues
 * [JDK-8345185](https://bugs.openjdk.org/browse/JDK-8345185): Update jpackage to not include service bindings by default (**Bug** - P3 - Approved)
 * [JDK-8346379](https://bugs.openjdk.org/browse/JDK-8346379): Update jpackage to not include service bindings by default (**CSR**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk24u.git pull/37/head:pull/37` \
`$ git checkout pull/37`

Update a local copy of the PR: \
`$ git checkout pull/37` \
`$ git pull https://git.openjdk.org/jdk24u.git pull/37/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 37`

View PR using the GUI difftool: \
`$ git pr show -t 37`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk24u/pull/37.diff">https://git.openjdk.org/jdk24u/pull/37.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk24u/pull/37#issuecomment-2619580915)
</details>
