### PR TITLE
8345959: Make JVM_IsStaticallyLinked JVM_LEAF

### DIFF
--- a/src/hotspot/share/prims/jvm.cpp
+++ b/src/hotspot/share/prims/jvm.cpp
@@ -3299,7 +3299,7 @@ JVM_LEAF(jboolean, JVM_IsForeignLinkerSupported(void))
   return ForeignGlobals::is_foreign_linker_supported() ? JNI_TRUE : JNI_FALSE;
 JVM_END
 
-JVM_ENTRY_NO_ENV(jboolean, JVM_IsStaticallyLinked(void))
+JVM_LEAF(jboolean, JVM_IsStaticallyLinked(void))
   return is_vm_statically_linked() ? JNI_TRUE : JNI_FALSE;
 JVM_END
 


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [05c56788](https://github.com/openjdk/jdk/commit/05c5678886f99290093bf7ad9fb589ee40bb5d29) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Jiangli Zhou on 11 Dec 2024 and was reviewed by Magnus Ihse Bursie.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8345959](https://bugs.openjdk.org/browse/JDK-8345959) needs maintainer approval

### Issue
 * [JDK-8345959](https://bugs.openjdk.org/browse/JDK-8345959): Make JVM_IsStaticallyLinked JVM_LEAF (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk24u.git pull/38/head:pull/38` \
`$ git checkout pull/38`

Update a local copy of the PR: \
`$ git checkout pull/38` \
`$ git pull https://git.openjdk.org/jdk24u.git pull/38/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 38`

View PR using the GUI difftool: \
`$ git pr show -t 38`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk24u/pull/38.diff">https://git.openjdk.org/jdk24u/pull/38.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk24u/pull/38#issuecomment-2619501916)
</details>
