### PR TITLE
8347506: Compatible OCSP readtimeout property with OCSP timeout

### DIFF
--- a/src/java.base/share/classes/sun/security/provider/certpath/OCSP.java
+++ b/src/java.base/share/classes/sun/security/provider/certpath/OCSP.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -67,7 +67,6 @@ public final class OCSP {
     private static final Debug debug = Debug.getInstance("certpath");
 
     private static final int DEFAULT_CONNECT_TIMEOUT = 15000;
-    private static final int DEFAULT_READ_TIMEOUT = 15000;
 
     /**
      * Integer value indicating the timeout length, in milliseconds, to be
@@ -83,7 +82,7 @@ public final class OCSP {
      * zero is interpreted as an infinite timeout.
      */
     private static final int READ_TIMEOUT = initializeTimeout(
-            "com.sun.security.ocsp.readtimeout", DEFAULT_READ_TIMEOUT);
+            "com.sun.security.ocsp.readtimeout", CONNECT_TIMEOUT);
 
     /**
      * Boolean value indicating whether OCSP client can use GET for OCSP

--- a/test/jdk/sun/security/provider/certpath/OCSP/OCSPReadTimeoutDefault.java
+++ b/test/jdk/sun/security/provider/certpath/OCSP/OCSPReadTimeoutDefault.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8347506
+ * @summary Compatible OCSP readtimeout property with OCSP timeout
+ * @modules java.base/sun.security.provider.certpath
+ * @run main/othervm
+ *      --add-opens java.base/sun.security.provider.certpath=ALL-UNNAMED
+ *      OCSPReadTimeoutDefault 15000
+ * @run main/othervm
+ *      --add-opens java.base/sun.security.provider.certpath=ALL-UNNAMED
+ *      -Dcom.sun.security.ocsp.timeout=6
+ *      OCSPReadTimeoutDefault 6000
+ * @run main/othervm
+ *      --add-opens java.base/sun.security.provider.certpath=ALL-UNNAMED
+ *      -Dcom.sun.security.ocsp.timeout=6 -Dcom.sun.security.ocsp.readtimeout=1
+ *      OCSPReadTimeoutDefault 1000
+ */
+
+import java.lang.reflect.*;
+
+public class OCSPReadTimeoutDefault {
+
+    public static void main(String[] args) throws Exception {
+        if (args == null || args.length < 1) {
+            throw new RuntimeException("Missing mandatory readtimeout value");
+        }
+
+        int expectedReadTimeout = Integer.parseInt(args[0]);
+
+        Class<?> ocspClazz = sun.security.provider.certpath.OCSP.class;
+        System.out.println("OCSP Class: " + ocspClazz);
+
+        Field cto = ocspClazz.getDeclaredField("CONNECT_TIMEOUT");
+        Field rto = ocspClazz.getDeclaredField("READ_TIMEOUT");
+        cto.setAccessible(true);
+        rto.setAccessible(true);
+        int ctoVal = cto.getInt(null);
+        int rtoVal = rto.getInt(null);
+
+        System.out.println("Expected read timeout: " + expectedReadTimeout);
+        System.out.println("CTOVal: " + ctoVal + ", RTOVal: " + rtoVal);
+        if (rtoVal != expectedReadTimeout) {
+            throw new RuntimeException("Expected read timeout value of " +
+                    expectedReadTimeout + ", found " + rtoVal);
+        }
+    }
+}


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8347749](https://bugs.openjdk.org/browse/JDK-8347749) to be approved
- [x] [JDK-8347506](https://bugs.openjdk.org/browse/JDK-8347506) needs maintainer approval

### Issues
 * [JDK-8347506](https://bugs.openjdk.org/browse/JDK-8347506): Compatible OCSP readtimeout property with OCSP timeout (**Bug** - P3 - Approved)
 * [JDK-8347749](https://bugs.openjdk.org/browse/JDK-8347749): Compatible OCSP readtimeout property with OCSP timeout (**CSR**)


### Reviewers
 * [Alexey Bakhtin](https://openjdk.org/census#abakhtin) (@alexeybakhtin - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk24u.git pull/39/head:pull/39` \
`$ git checkout pull/39`

Update a local copy of the PR: \
`$ git checkout pull/39` \
`$ git pull https://git.openjdk.org/jdk24u.git pull/39/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 39`

View PR using the GUI difftool: \
`$ git pr show -t 39`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk24u/pull/39.diff">https://git.openjdk.org/jdk24u/pull/39.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk24u/pull/39#issuecomment-2619656646)
</details>
