### PR TITLE
8339356: Test javax/net/ssl/SSLSocket/Tls13PacketSize.java failed with java.net.SocketException: An established connection was aborted by the software in your host machine

### DIFF
--- a/test/jdk/javax/net/ssl/SSLSocket/Tls13PacketSize.java
+++ b/test/jdk/javax/net/ssl/SSLSocket/Tls13PacketSize.java
@@ -72,6 +72,10 @@ public class Tls13PacketSize extends SSLSocketTemplate {
 
         sslOS.write(appData);
         sslOS.flush();
+        int drained = 1;
+        while (drained < appData.length) {
+            drained += sslIS.read(appData, drained, appData.length - drained);
+        }
     }
 
     /*


### PR DESCRIPTION
Straight Backport. Test passed

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8339356](https://bugs.openjdk.org/browse/JDK-8339356) needs maintainer approval

### Issue
 * [JDK-8339356](https://bugs.openjdk.org/browse/JDK-8339356): Test javax/net/ssl/SSLSocket/Tls13PacketSize.java failed with java.net.SocketException: An established connection was aborted by the software in your host machine (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk24u.git pull/43/head:pull/43` \
`$ git checkout pull/43`

Update a local copy of the PR: \
`$ git checkout pull/43` \
`$ git pull https://git.openjdk.org/jdk24u.git pull/43/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 43`

View PR using the GUI difftool: \
`$ git pr show -t 43`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk24u/pull/43.diff">https://git.openjdk.org/jdk24u/pull/43.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk24u/pull/43#issuecomment-2631427737)
</details>
