### PR TITLE
8347038: [JMH] jdk.incubator.vector.SpiltReplicate fails NoClassDefFoundError

### DIFF
--- a/test/micro/org/openjdk/bench/jdk/incubator/vector/SpiltReplicate.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/vector/SpiltReplicate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,7 +31,7 @@ import org.openjdk.jmh.annotations.*;
 
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
-@Fork(1)
+@Fork(value=1, jvmArgs={"--add-modules=jdk.incubator.vector"})
 public class SpiltReplicate {
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public long broadcastInt() {


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [4d8fb807](https://github.com/openjdk/jdk/commit/4d8fb80732fd17352c36254c6dfc1be5dbfbacf1) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backport  fix the JMH test bug which report "NoClassDefFoundError" fails, test-fix only, no risk.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8347038](https://bugs.openjdk.org/browse/JDK-8347038) needs maintainer approval

### Issue
 * [JDK-8347038](https://bugs.openjdk.org/browse/JDK-8347038): [JMH] jdk.incubator.vector.SpiltReplicate fails NoClassDefFoundError (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk24u.git pull/47/head:pull/47` \
`$ git checkout pull/47`

Update a local copy of the PR: \
`$ git checkout pull/47` \
`$ git pull https://git.openjdk.org/jdk24u.git pull/47/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 47`

View PR using the GUI difftool: \
`$ git pr show -t 47`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk24u/pull/47.diff">https://git.openjdk.org/jdk24u/pull/47.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk24u/pull/47#issuecomment-2635996012)
</details>
