### PR TITLE
8346671: java/nio/file/Files/probeContentType/Basic.java fails on Windows 2025

### DIFF
--- a/test/jdk/java/nio/file/Files/probeContentType/Basic.java
+++ b/test/jdk/java/nio/file/Files/probeContentType/Basic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -40,6 +40,7 @@ import java.util.stream.Stream;
 
 import jdk.internal.util.OperatingSystem;
 import jdk.internal.util.OSVersion;
+import jdk.internal.util.StaticProperty;
 
 /**
  * Uses Files.probeContentType to probe html file, custom file type, and minimal
@@ -83,7 +84,7 @@ public class Basic {
         if (!expected.equals(actual)) {
             if (!OperatingSystem.isWindows()) {
                 Path userMimeTypes =
-                    Path.of(System.getProperty("user.home"), ".mime.types");
+                    Path.of(StaticProperty.userHome(), ".mime.types");
                 checkMimeTypesFile(userMimeTypes);
 
                 Path etcMimeTypes = Path.of("/etc/mime.types");
@@ -188,9 +189,10 @@ public class Basic {
         exTypes.add(new ExType("xlsx", List.of("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet")));
         exTypes.add(new ExType("wasm", List.of("application/wasm")));
 
-        // extensions with content type that differs on Windows 11+
+        // extensions with content type that differs on Windows 11+ and
+        // Windows Server 2025
         if (OperatingSystem.isWindows() &&
-            (System.getProperty("os.name").endsWith("11") ||
+            (StaticProperty.osName().matches("^.*[11|2025]$") ||
                 new OSVersion(10, 0).compareTo(OSVersion.current()) > 0)) {
             System.out.println("Windows 11+ detected: using different types");
             exTypes.add(new ExType("bz2", List.of("application/bz2", "application/x-bzip2", "application/x-bzip", "application/x-compressed")));


### PR DESCRIPTION
I backport this to improve testing on new Windows.

With a lot of hurry I could make jdk24 RDP2, which ends tomorrow, Feb 6th.
But I want to run this through our testing, so I think jdk24u is the better target.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8346671](https://bugs.openjdk.org/browse/JDK-8346671) needs maintainer approval

### Issue
 * [JDK-8346671](https://bugs.openjdk.org/browse/JDK-8346671): java/nio/file/Files/probeContentType/Basic.java fails on Windows 2025 (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk24u.git pull/48/head:pull/48` \
`$ git checkout pull/48`

Update a local copy of the PR: \
`$ git checkout pull/48` \
`$ git pull https://git.openjdk.org/jdk24u.git pull/48/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 48`

View PR using the GUI difftool: \
`$ git pr show -t 48`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk24u/pull/48.diff">https://git.openjdk.org/jdk24u/pull/48.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk24u/pull/48#issuecomment-2636007154)
</details>
