### PR TITLE
8349002: GenShen: Deadlock during shutdown

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahGenerationalControlThread.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGenerationalControlThread.cpp
@@ -332,6 +332,8 @@ void ShenandoahGenerationalControlThread::run_service() {
     }
   }
 
+  set_gc_mode(stopped);
+
   // Wait for the actual stop(), can't leave run_service() earlier.
   while (!should_terminate()) {
     os::naked_short_sleep(ShenandoahControlIntervalMin);
@@ -827,6 +829,7 @@ const char* ShenandoahGenerationalControlThread::gc_mode_name(ShenandoahGenerati
     case stw_full:          return "full";
     case servicing_old:     return "old";
     case bootstrapping_old: return "bootstrap";
+    case stopped:           return "stopped";
     default:                return "unknown";
   }
 }

--- a/src/hotspot/share/gc/shenandoah/shenandoahGenerationalControlThread.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGenerationalControlThread.hpp
@@ -48,7 +48,8 @@ public:
     stw_degenerated,
     stw_full,
     bootstrapping_old,
-    servicing_old
+    servicing_old,
+    stopped
   } GCMode;
 
 private:


### PR DESCRIPTION
Clean backport. Fixes bug recently introduced by [JDK-8345970](https://bugs.openjdk.org/browse/JDK-8345970).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8349002](https://bugs.openjdk.org/browse/JDK-8349002) needs maintainer approval

### Issue
 * [JDK-8349002](https://bugs.openjdk.org/browse/JDK-8349002): GenShen: Deadlock during shutdown (**Task** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk24u.git pull/56/head:pull/56` \
`$ git checkout pull/56`

Update a local copy of the PR: \
`$ git checkout pull/56` \
`$ git pull https://git.openjdk.org/jdk24u.git pull/56/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 56`

View PR using the GUI difftool: \
`$ git pr show -t 56`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk24u/pull/56.diff">https://git.openjdk.org/jdk24u/pull/56.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk24u/pull/56#issuecomment-2637936952)
</details>
