### PR TITLE
8349058: 'internal proprietary API' warnings make javac warnings unusable

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/ClassFinder.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/ClassFinder.java
@@ -241,7 +241,7 @@ public class ClassFinder {
      * available from the module system.
      */
     long getSupplementaryFlags(ClassSymbol c) {
-        if (c.name == names.module_info) {
+        if (jrtIndex == null || !jrtIndex.isInJRT(c.classfile) || c.name == names.module_info) {
             return 0;
         }
 
@@ -257,22 +257,17 @@ public class ClassFinder {
             try {
                 ModuleSymbol owningModule = packge.modle;
                 if (owningModule == syms.noModule) {
-                    if (jrtIndex != null && jrtIndex.isInJRT(c.classfile)) {
-                        JRTIndex.CtSym ctSym = jrtIndex.getCtSym(packge.flatName());
-                        Profile minProfile = Profile.DEFAULT;
-                        if (ctSym.proprietary)
-                            newFlags |= PROPRIETARY;
-                        if (ctSym.minProfile != null)
-                            minProfile = Profile.lookup(ctSym.minProfile);
-                        if (profile != Profile.DEFAULT && minProfile.value > profile.value) {
-                            newFlags |= NOT_IN_PROFILE;
-                        }
+                    JRTIndex.CtSym ctSym = jrtIndex.getCtSym(packge.flatName());
+                    Profile minProfile = Profile.DEFAULT;
+                    if (ctSym.proprietary)
+                        newFlags |= PROPRIETARY;
+                    if (ctSym.minProfile != null)
+                        minProfile = Profile.lookup(ctSym.minProfile);
+                    if (profile != Profile.DEFAULT && minProfile.value > profile.value) {
+                        newFlags |= NOT_IN_PROFILE;
                     }
                 } else if (owningModule.name == names.jdk_unsupported) {
                     newFlags |= PROPRIETARY;
-                } else {
-                    // don't accumulate user modules in supplementaryFlags
-                    return 0;
                 }
             } catch (IOException ignore) {
             }


### PR DESCRIPTION
Hi,

This pull request contains a backport of commit [1ab1c1d53b86228be85aac96fa5d69db39ac6317](https://github.com/openjdk/jdk/commit/1ab1c1d53b86228be85aac96fa5d69db39ac6317) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository to fix [JDK-8349058](https://bugs.openjdk.org/browse/JDK-8349058).

It's a clean backport that partially backs out an earlier change, the affected test passes.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8349058](https://bugs.openjdk.org/browse/JDK-8349058) needs maintainer approval

### Issue
 * [JDK-8349058](https://bugs.openjdk.org/browse/JDK-8349058): 'internal proprietary API' warnings make javac warnings unusable (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk24u.git pull/69/head:pull/69` \
`$ git checkout pull/69`

Update a local copy of the PR: \
`$ git checkout pull/69` \
`$ git pull https://git.openjdk.org/jdk24u.git pull/69/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 69`

View PR using the GUI difftool: \
`$ git pr show -t 69`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk24u/pull/69.diff">https://git.openjdk.org/jdk24u/pull/69.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk24u/pull/69#issuecomment-2651474854)
</details>
