### PR TITLE
8346880: [aix] java/lang/ProcessHandle/InfoTest.java still fails: "reported cputime less than expected"

### DIFF
--- a/src/java.base/aix/native/libjava/ProcessHandleImpl_aix.c
+++ b/src/java.base/aix/native/libjava/ProcessHandleImpl_aix.c
@@ -162,7 +162,24 @@ jint os_getChildren(JNIEnv *env, jlong jpid, jlongArray jarray,
 }
 
 pid_t os_getParentPidAndTimings(JNIEnv *env, pid_t pid, jlong *total, jlong *start) {
-    return unix_getParentPidAndTimings(env, pid, total, start);
+    pid_t the_pid = pid;
+    struct procentry64 ProcessBuffer;
+
+    if (getprocs64(&ProcessBuffer, sizeof(ProcessBuffer), NULL, sizeof(struct fdsinfo64), &the_pid, 1) <= 0) {
+        return -1;
+    }
+
+    // Validate the pid before returning the info
+    if (kill(pid, 0) < 0) {
+        return -1;
+    }
+
+    *total = ((ProcessBuffer.pi_ru.ru_utime.tv_sec + ProcessBuffer.pi_ru.ru_stime.tv_sec) * 1000000000L) +
+             ((ProcessBuffer.pi_ru.ru_utime.tv_usec + ProcessBuffer.pi_ru.ru_stime.tv_usec));
+
+    *start = ProcessBuffer.pi_start * (jlong)1000;
+
+    return (pid_t) ProcessBuffer.pi_ppid;
 }
 
 void os_getCmdlineAndUserInfo(JNIEnv *env, jobject jinfo, pid_t pid) {


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8346880](https://bugs.openjdk.org/browse/JDK-8346880) needs maintainer approval

### Issue
 * [JDK-8346880](https://bugs.openjdk.org/browse/JDK-8346880): [aix] java/lang/ProcessHandle/InfoTest.java still fails: "reported cputime less than expected" (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk24u.git pull/75/head:pull/75` \
`$ git checkout pull/75`

Update a local copy of the PR: \
`$ git checkout pull/75` \
`$ git pull https://git.openjdk.org/jdk24u.git pull/75/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 75`

View PR using the GUI difftool: \
`$ git pr show -t 75`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk24u/pull/75.diff">https://git.openjdk.org/jdk24u/pull/75.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk24u/pull/75#issuecomment-2656923677)
</details>
