### PR TITLE
8349787: java/lang/Thread/virtual/ThreadPollOnYield.java#default passes unexpectedly without libVThreadPinner.so

### DIFF
--- a/test/jdk/java/lang/Thread/virtual/ThreadPollOnYield.java
+++ b/test/jdk/java/lang/Thread/virtual/ThreadPollOnYield.java
@@ -40,13 +40,16 @@
  */
 
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.CountDownLatch;
 
 import jdk.test.lib.thread.VThreadPinner;
 import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.*;
 
 class ThreadPollOnYield {
+    private static final CountDownLatch started = new CountDownLatch(1);
     static void foo(AtomicBoolean done) {
+        started.countDown();
         while (!done.get()) {
             Thread.yield();
         }
@@ -58,7 +61,7 @@ class ThreadPollOnYield {
         var vthread = Thread.ofVirtual().start(() -> {
             VThreadPinner.runPinned(() -> foo(done));
         });
-        Thread.sleep(5000);
+        started.await();
         done.set(true);
         vthread.join();
 


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [adc3f53d](https://github.com/openjdk/jdk/commit/adc3f53d2403cd414a91e71c079b4108b2346da0) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by SendaoYan on 13 Feb 2025 and was reviewed by Alan Bateman.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8349787](https://bugs.openjdk.org/browse/JDK-8349787) needs maintainer approval

### Issue
 * [JDK-8349787](https://bugs.openjdk.org/browse/JDK-8349787): java/lang/Thread/virtual/ThreadPollOnYield.java#default passes unexpectedly without libVThreadPinner.so (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk24u.git pull/77/head:pull/77` \
`$ git checkout pull/77`

Update a local copy of the PR: \
`$ git checkout pull/77` \
`$ git pull https://git.openjdk.org/jdk24u.git pull/77/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 77`

View PR using the GUI difftool: \
`$ git pr show -t 77`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk24u/pull/77.diff">https://git.openjdk.org/jdk24u/pull/77.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk24u/pull/77#issuecomment-2658193565)
</details>
