### PR TITLE
8349751: AIX build failure after upgrade pipewire to 1.3.81

### DIFF
--- a/src/java.desktop/unix/native/libpipewire/include/spa/utils/endian.h
+++ b/src/java.desktop/unix/native/libpipewire/include/spa/utils/endian.h
@@ -18,6 +18,10 @@
 #define bswap_16 _byteswap_ushort
 #define bswap_32 _byteswap_ulong
 #define bswap_64 _byteswap_uint64
+#elif defined(AIX)
+#include <sys/machine.h>
+#define __BIG_ENDIAN      BIG_ENDIAN
+#define __BYTE_ORDER      BIG_ENDIAN
 #else
 #include <endian.h>
 #include <byteswap.h>


### PR DESCRIPTION
Clean backport of [JDK-8349751](https://bugs.openjdk.org/browse/JDK-8349751).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8349751](https://bugs.openjdk.org/browse/JDK-8349751) needs maintainer approval

### Issue
 * [JDK-8349751](https://bugs.openjdk.org/browse/JDK-8349751): AIX build failure after upgrade pipewire to 1.3.81 (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk24u.git pull/79/head:pull/79` \
`$ git checkout pull/79`

Update a local copy of the PR: \
`$ git checkout pull/79` \
`$ git pull https://git.openjdk.org/jdk24u.git pull/79/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 79`

View PR using the GUI difftool: \
`$ git pr show -t 79`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk24u/pull/79.diff">https://git.openjdk.org/jdk24u/pull/79.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk24u/pull/79#issuecomment-2660190253)
</details>
