### PR TITLE
8350137: After JDK-8348975, Linux builds contain man pages for windows only tools

### DIFF
--- a/make/Docs.gmk
+++ b/make/Docs.gmk
@@ -680,7 +680,7 @@ ifeq ($(ENABLE_PANDOC), true)
 
   $(foreach m, $(ALL_MODULES), \
     $(eval MAN_$m := $(call ApplySpecFilter, $(filter %.md, $(call FindFiles, \
-          $(call FindModuleManDirs, $m))))) \
+          $(call FindModuleManDirsForDocs, $m))))) \
     $(if $(MAN_$m), \
       $(eval $(call SetupProcessMarkdown, MAN_TO_HTML_$m, \
         FILES := $(MAN_$m), \

--- a/make/common/Modules.gmk
+++ b/make/common/Modules.gmk
@@ -92,7 +92,10 @@ SRC_SUBDIRS += share/classes
 
 SPEC_SUBDIRS += share/specs
 
-MAN_SUBDIRS += share/man windows/man
+MAN_SUBDIRS += share/man $(TARGET_OS)/man
+
+# The docs should include the sum of all man pages for all platforms
+MAN_DOCS_SUBDIRS += share/man windows/man
 
 # Find all module-info.java files for the current build target platform and
 # configuration.
@@ -157,6 +160,10 @@ FindModuleSpecsDirs = \
 FindModuleManDirs = \
     $(strip $(wildcard \
         $(foreach sub, $(MAN_SUBDIRS), $(addsuffix /$(strip $1)/$(sub), $(TOP_SRC_DIRS)))))
+
+FindModuleManDirsForDocs = \
+    $(strip $(wildcard \
+        $(foreach sub, $(MAN_DOCS_SUBDIRS), $(addsuffix /$(strip $1)/$(sub), $(TOP_SRC_DIRS)))))
 
 # Construct the complete module source path
 GetModuleSrcPath = \


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [53db5764](https://github.com/openjdk/jdk/commit/53db57648a09c4c380064eea11fcdb680011d741) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Nizar Benalla on 20 Feb 2025 and was reviewed by Erik Joelsson.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8350137](https://bugs.openjdk.org/browse/JDK-8350137) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8350137](https://bugs.openjdk.org/browse/JDK-8350137): After JDK-8348975, Linux builds contain man pages for windows only tools (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk24u.git pull/89/head:pull/89` \
`$ git checkout pull/89`

Update a local copy of the PR: \
`$ git checkout pull/89` \
`$ git pull https://git.openjdk.org/jdk24u.git pull/89/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 89`

View PR using the GUI difftool: \
`$ git pr show -t 89`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk24u/pull/89.diff">https://git.openjdk.org/jdk24u/pull/89.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk24u/pull/89#issuecomment-2678820810)
</details>
