### PR TITLE
8346832: runtime/CompressedOops/CompressedCPUSpecificClassSpaceReservation.java fails on RISC-V

### DIFF
--- a/src/hotspot/cpu/riscv/compressedKlass_riscv.cpp
+++ b/src/hotspot/cpu/riscv/compressedKlass_riscv.cpp
@@ -31,7 +31,7 @@ char* CompressedKlassPointers::reserve_address_space_for_compressed_classes(size
 
   char* result = nullptr;
 
-  // RiscV loads a 64-bit immediate in up to four separate steps, splitting it into four different sections
+  // RISC-V loads a 64-bit immediate in up to four separate steps, splitting it into four different sections
   // (two 32-bit sections, each split into two subsections of 20/12 bits).
   //
   // 63 ....... 44 43 ... 32 31 ....... 12 11 ... 0
@@ -50,11 +50,6 @@ char* CompressedKlassPointers::reserve_address_space_for_compressed_classes(size
   // - if !can_optimize_for_zero_base, a <4GB mapping start is still good, the resulting immediate can be encoded
   //   with one instruction (2)
   result = reserve_address_space_for_unscaled_encoding(size, aslr);
-
-  // Failing that, attempt to reserve for base=zero shift>0
-  if (result == nullptr && optimize_for_zero_base) {
-    result = reserve_address_space_for_zerobased_encoding(size, aslr);
-  }
 
   // Failing that, optimize for case (3) - a base with only bits set between [32-44)
   if (result == nullptr) {

--- a/test/hotspot/jtreg/runtime/CompressedOops/CompressedCPUSpecificClassSpaceReservation.java
+++ b/test/hotspot/jtreg/runtime/CompressedOops/CompressedCPUSpecificClassSpaceReservation.java
@@ -85,15 +85,8 @@ public class CompressedCPUSpecificClassSpaceReservation {
             output.shouldContain(tryReserveFor16bitMoveIntoQ3);
         } else if (Platform.isRISCV64()) {
             output.shouldContain(tryReserveForUnscaled); // unconditionally
-            if (CDS) {
-                output.shouldNotContain(tryReserveForZeroBased);
-                // bits 32..44
-                output.shouldContain("reserve_between (range [0x0000000100000000-0x0000100000000000)");
-            } else {
-                output.shouldContain(tryReserveForZeroBased);
-                // bits 32..44, but not lower than zero-based limit
-                output.shouldContain("reserve_between (range [0x0000000800000000-0x0000100000000000)");
-            }
+            // bits 32..44
+            output.shouldContain("reserve_between (range [0x0000000100000000-0x0000100000000000)");
             // bits 44..64
             output.shouldContain("reserve_between (range [0x0000100000000000-0xffffffffffffffff)");
         } else if (Platform.isS390x()) {


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [de025036](https://github.com/openjdk/jdk/commit/de0250368edbf4e9bebf326778f8f8773b69b84c) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Fei Yang on 7 Jan 2025 and was reviewed by Thomas Stuefe and Feilong Jiang.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8346832](https://bugs.openjdk.org/browse/JDK-8346832) needs maintainer approval

### Issue
 * [JDK-8346832](https://bugs.openjdk.org/browse/JDK-8346832): runtime/CompressedOops/CompressedCPUSpecificClassSpaceReservation.java fails on RISC-V (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk24u.git pull/90/head:pull/90` \
`$ git checkout pull/90`

Update a local copy of the PR: \
`$ git checkout pull/90` \
`$ git pull https://git.openjdk.org/jdk24u.git pull/90/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 90`

View PR using the GUI difftool: \
`$ git pr show -t 90`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk24u/pull/90.diff">https://git.openjdk.org/jdk24u/pull/90.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk24u/pull/90#issuecomment-2680172693)
</details>
