### PR TITLE
8339889: Several compiler tests ignore vm flags and not marked as flagless

### DIFF
--- a/test/hotspot/jtreg/compiler/c2/TestReduceAllocationAndHeapDump.java
+++ b/test/hotspot/jtreg/compiler/c2/TestReduceAllocationAndHeapDump.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -54,7 +54,7 @@ public class TestReduceAllocationAndHeapDump {
                 HeapDumper.class.getName()
             };
 
-            ProcessBuilder pb = ProcessTools.createLimitedTestJavaProcessBuilder(dumperArgs);
+            ProcessBuilder pb = ProcessTools.createTestJavaProcessBuilder(dumperArgs);
             Process p = pb.start();
             OutputAnalyzer out = new OutputAnalyzer(p);
 

--- a/test/hotspot/jtreg/compiler/calls/NativeCalls.java
+++ b/test/hotspot/jtreg/compiler/calls/NativeCalls.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
  * Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -104,7 +105,7 @@ public class NativeCalls {
             ArrayList<String> command = new ArrayList<String>(v.options);
             command.addAll(baseOptions);
             command.add(v.compile);
-            ProcessBuilder pb = ProcessTools.createLimitedTestJavaProcessBuilder(command);
+            ProcessBuilder pb = ProcessTools.createTestJavaProcessBuilder(command);
             OutputAnalyzer analyzer = new OutputAnalyzer(pb.start());
             analyzer.shouldHaveExitValue(0);
             System.out.println(analyzer.getOutput());

--- a/test/hotspot/jtreg/compiler/debug/TestStress.java
+++ b/test/hotspot/jtreg/compiler/debug/TestStress.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,6 +32,7 @@ import jdk.test.lib.Asserts;
  * @key stress randomness
  * @bug 8252219 8256535 8317349
  * @requires vm.debug == true & vm.compiler2.enabled
+ * @requires vm.flagless
  * @summary Tests that stress compilations with the same seed yield the same
  *          IGVN, CCP, and macro expansion traces.
  * @library /test/lib /

--- a/test/hotspot/jtreg/compiler/inlining/TestDuplicatedLateInliningOutput.java
+++ b/test/hotspot/jtreg/compiler/inlining/TestDuplicatedLateInliningOutput.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2023, Red Hat and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -27,6 +28,7 @@
  * @summary late inlining output shouldn't produce both failure and success messages
  * @library /test/lib
  * @requires vm.compiler2.enabled
+ * @requires vm.flagless
  * @run driver compiler.inlining.TestDuplicatedLateInliningOutput
  */
 


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [829d7a84](https://github.com/openjdk/jdk/commit/829d7a845e18ec483379abf3a3fccb596d899f25) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Leonid Mesnik on 25 Feb 2025 and was reviewed by Tobias Hartmann.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8339889](https://bugs.openjdk.org/browse/JDK-8339889) needs maintainer approval

### Issue
 * [JDK-8339889](https://bugs.openjdk.org/browse/JDK-8339889): Several compiler tests ignore vm flags and not marked as flagless (**Sub-task** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk24u.git pull/94/head:pull/94` \
`$ git checkout pull/94`

Update a local copy of the PR: \
`$ git checkout pull/94` \
`$ git pull https://git.openjdk.org/jdk24u.git pull/94/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 94`

View PR using the GUI difftool: \
`$ git pr show -t 94`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk24u/pull/94.diff">https://git.openjdk.org/jdk24u/pull/94.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk24u/pull/94#issuecomment-2683757145)
</details>
