### PR TITLE
8314840: 3 gc/epsilon tests ignore external vm options

### DIFF
--- a/test/hotspot/jtreg/gc/epsilon/TestDieDefault.java
+++ b/test/hotspot/jtreg/gc/epsilon/TestDieDefault.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018, Red Hat, Inc. All rights reserved.
+ * Copyright (c) 2017, 2025, Red Hat, Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,13 +37,13 @@ import jdk.test.lib.process.ProcessTools;
 public class TestDieDefault {
 
   public static void passWith(String... args) throws Exception {
-    OutputAnalyzer out = ProcessTools.executeLimitedTestJava(args);
+    OutputAnalyzer out = ProcessTools.executeTestJava(args);
     out.shouldNotContain("OutOfMemoryError");
     out.shouldHaveExitValue(0);
   }
 
   public static void failWith(String... args) throws Exception {
-    OutputAnalyzer out = ProcessTools.executeLimitedTestJava(args);
+    OutputAnalyzer out = ProcessTools.executeTestJava(args);
     out.shouldContain("OutOfMemoryError");
     if (out.getExitValue() == 0) {
       throw new IllegalStateException("Should have failed with non-zero exit code");

--- a/test/hotspot/jtreg/gc/epsilon/TestDieWithHeapDump.java
+++ b/test/hotspot/jtreg/gc/epsilon/TestDieWithHeapDump.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018, Red Hat, Inc. All rights reserved.
+ * Copyright (c) 2017, 2025, Red Hat, Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,13 +38,13 @@ import jdk.test.lib.process.ProcessTools;
 public class TestDieWithHeapDump {
 
   public static void passWith(String... args) throws Exception {
-    OutputAnalyzer out = ProcessTools.executeLimitedTestJava(args);
+    OutputAnalyzer out = ProcessTools.executeTestJava(args);
     out.shouldNotContain("OutOfMemoryError");
     out.shouldHaveExitValue(0);
   }
 
   public static void failWith(String... args) throws Exception {
-    ProcessBuilder pb = ProcessTools.createLimitedTestJavaProcessBuilder(args);
+    ProcessBuilder pb = ProcessTools.createTestJavaProcessBuilder(args);
     Process p = pb.start();
     OutputAnalyzer out = new OutputAnalyzer(p);
     out.shouldContain("OutOfMemoryError");

--- a/test/hotspot/jtreg/gc/epsilon/TestDieWithOnError.java
+++ b/test/hotspot/jtreg/gc/epsilon/TestDieWithOnError.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018, Red Hat, Inc. All rights reserved.
+ * Copyright (c) 2017, 2025, Red Hat, Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,14 +39,14 @@ public class TestDieWithOnError {
   static String ON_ERR_MSG = "Epsilon error handler message";
 
   public static void passWith(String... args) throws Exception {
-    OutputAnalyzer out = ProcessTools.executeLimitedTestJava(args);
+    OutputAnalyzer out = ProcessTools.executeTestJava(args);
     out.shouldNotContain("OutOfMemoryError");
     out.stdoutShouldNotMatch("^" + ON_ERR_MSG);
     out.shouldHaveExitValue(0);
   }
 
   public static void failWith(String... args) throws Exception {
-    OutputAnalyzer out = ProcessTools.executeLimitedTestJava(args);
+    OutputAnalyzer out = ProcessTools.executeTestJava(args);
     out.shouldContain("OutOfMemoryError");
     if (out.getExitValue() == 0) {
       throw new IllegalStateException("Should have failed with non-zero exit code");


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [799ac528](https://github.com/openjdk/jdk/commit/799ac5288efbbb89e21319cd45657c8f817ad680) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Ramkumar Sunderbabu on 27 Feb 2025 and was reviewed by Thomas Schatzl.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8314840](https://bugs.openjdk.org/browse/JDK-8314840) needs maintainer approval

### Issue
 * [JDK-8314840](https://bugs.openjdk.org/browse/JDK-8314840): 3 gc/epsilon tests ignore external vm options (**Sub-task** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk24u.git pull/95/head:pull/95` \
`$ git checkout pull/95`

Update a local copy of the PR: \
`$ git checkout pull/95` \
`$ git pull https://git.openjdk.org/jdk24u.git pull/95/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 95`

View PR using the GUI difftool: \
`$ git pr show -t 95`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk24u/pull/95.diff">https://git.openjdk.org/jdk24u/pull/95.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk24u/pull/95#issuecomment-2687923706)
</details>
