### PR TITLE
8294155: Exception thrown before awaitAndCheck hangs PassFailJFrame

### DIFF
--- a/test/jdk/java/awt/regtesthelpers/PassFailJFrame.java
+++ b/test/jdk/java/awt/regtesthelpers/PassFailJFrame.java
@@ -1787,8 +1787,20 @@ public final class PassFailJFrame {
 
         public PassFailJFrame build() throws InterruptedException,
                 InvocationTargetException {
-            validate();
-            return new PassFailJFrame(this);
+            try {
+                validate();
+                return new PassFailJFrame(this);
+            } catch (final Throwable t) {
+                // Dispose of all the windows, including those that may not
+                // be registered with PassFailJFrame to allow AWT to shut down
+                try {
+                    invokeOnEDT(() -> Arrays.stream(Window.getWindows())
+                                            .forEach(Window::dispose));
+                } catch (Throwable edt) {
+                    t.addSuppressed(edt);
+                }
+                throw t;
+            }
         }
 
         /**


### PR DESCRIPTION
This pull request contains a backport of commit [906358d3](https://github.com/openjdk/jdk/commit/906358d3a14ce755fec771f0a6bb856b3a8f3297) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Alexey Ivanov on 17 Feb 2025 and was reviewed by Sergey Bylokhov, Alexander Zvegintsev and Alexander Zuev.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8294155](https://bugs.openjdk.org/browse/JDK-8294155) needs maintainer approval

### Issue
 * [JDK-8294155](https://bugs.openjdk.org/browse/JDK-8294155): Exception thrown before awaitAndCheck hangs PassFailJFrame (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk24u.git pull/98/head:pull/98` \
`$ git checkout pull/98`

Update a local copy of the PR: \
`$ git checkout pull/98` \
`$ git pull https://git.openjdk.org/jdk24u.git pull/98/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 98`

View PR using the GUI difftool: \
`$ git pr show -t 98`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk24u/pull/98.diff">https://git.openjdk.org/jdk24u/pull/98.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk24u/pull/98#issuecomment-2695315356)
</details>
