### PR TITLE
8350483: AArch64: turn on signum intrinsics by default on Ampere CPUs

### DIFF
--- a/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
@@ -162,6 +162,9 @@ void VM_Version::initialize() {
         (_model == CPU_MODEL_AMPERE_1A || _model == CPU_MODEL_AMPERE_1B)) {
       FLAG_SET_DEFAULT(CodeEntryAlignment, 32);
     }
+    if (FLAG_IS_DEFAULT(UseSignumIntrinsic)) {
+      FLAG_SET_DEFAULT(UseSignumIntrinsic, true);
+    }
   }
 
   // ThunderX


### PR DESCRIPTION
Backport the commit to set `-XX:+UseSignumIntrinsic` by default for Ampere CPUs. It is to fix performance problem observed on JMH cases `vm.compiler.Signum|java.lang.*MathBench.sig[nN]um*`. In the worst test cases, run speed is 1~2% of the expected (patched) and functions got severely impacted. So, the fix can be regarded not only a performance fix but also a function problem solving in a manner, which can be a point to support this backport request too.

The backporting is of low risk as the patch is limited to Ampere CPUs only and well verified on Ampere-1A with related jmh and jtreg tier1 tests.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8350483](https://bugs.openjdk.org/browse/JDK-8350483) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8350483](https://bugs.openjdk.org/browse/JDK-8350483): AArch64: turn on signum intrinsics by default on Ampere CPUs (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk24u.git pull/101/head:pull/101` \
`$ git checkout pull/101`

Update a local copy of the PR: \
`$ git checkout pull/101` \
`$ git pull https://git.openjdk.org/jdk24u.git pull/101/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 101`

View PR using the GUI difftool: \
`$ git pr show -t 101`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk24u/pull/101.diff">https://git.openjdk.org/jdk24u/pull/101.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk24u/pull/101#issuecomment-2696148940)
</details>
