### PR TITLE
8350820: OperatingSystemMXBean CpuLoad() methods return -1.0 on Windows

### DIFF
--- a/src/jdk.management/windows/native/libmanagement_ext/OperatingSystemImpl.c
+++ b/src/jdk.management/windows/native/libmanagement_ext/OperatingSystemImpl.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -436,13 +436,13 @@ makeFullCounterPath(const char* const objectName,
             return NULL;
         }
 
-        snprintf(fullCounterPath,
-                 fullCounterPathLen,
-                 PROCESS_OBJECT_INSTANCE_COUNTER_FMT,
-                 objectName,
-                 imageName,
-                 instance,
-                 counterName);
+        _snprintf(fullCounterPath,
+                  fullCounterPathLen,
+                  PROCESS_OBJECT_INSTANCE_COUNTER_FMT,
+                  objectName,
+                  imageName,
+                  instance,
+                  counterName);
     } else {
         if (instance) {
             /*
@@ -472,18 +472,18 @@ makeFullCounterPath(const char* const objectName,
         }
 
         if (instance) {
-            snprintf(fullCounterPath,
-                     fullCounterPathLen,
-                     OBJECT_WITH_INSTANCES_COUNTER_FMT,
-                     objectName,
-                     instance,
-                     counterName);
+            _snprintf(fullCounterPath,
+                      fullCounterPathLen,
+                      OBJECT_WITH_INSTANCES_COUNTER_FMT,
+                      objectName,
+                      instance,
+                      counterName);
         } else {
-            snprintf(fullCounterPath,
-                     fullCounterPathLen,
-                     OBJECT_COUNTER_FMT,
-                     objectName,
-                     counterName);
+            _snprintf(fullCounterPath,
+                      fullCounterPathLen,
+                      OBJECT_COUNTER_FMT,
+                      objectName,
+                      counterName);
         }
     }
 
@@ -719,10 +719,10 @@ currentQueryIndexForProcess(void) {
             PDH_FMT_COUNTERVALUE counterValue;
             PDH_STATUS res;
 
-            snprintf(fullIDProcessCounterPath,
-                     MAX_PATH,
-                     pdhIDProcessCounterFmt,
-                     index);
+            _snprintf(fullIDProcessCounterPath,
+                      MAX_PATH,
+                      pdhIDProcessCounterFmt,
+                      index);
 
             if (addCounter(tmpQuery, fullIDProcessCounterPath, &handleCounter) != 0) {
                 break;
@@ -1059,13 +1059,13 @@ allocateAndInitializePdhConstants() {
     }
 
     /* "\Process(java#%d)\ID Process" */
-    snprintf(pdhIDProcessCounterFmt,
-             pdhIDProcessCounterFmtLen,
-             PROCESS_OBJECT_INSTANCE_COUNTER_FMT,
-             pdhLocalizedProcessObject,
-             pdhProcessImageName,
-             "%d",
-             pdhLocalizedIDProcessCounter);
+    _snprintf(pdhIDProcessCounterFmt,
+              pdhIDProcessCounterFmtLen,
+              PROCESS_OBJECT_INSTANCE_COUNTER_FMT,
+              pdhLocalizedProcessObject,
+              pdhProcessImageName,
+              "%d",
+              pdhLocalizedIDProcessCounter);
 
     pdhIDProcessCounterFmt[pdhIDProcessCounterFmtLen] = '\0';
 


### PR DESCRIPTION
Reviewed-by: kevinw, jwaters

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8350820](https://bugs.openjdk.org/browse/JDK-8350820) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8350820](https://bugs.openjdk.org/browse/JDK-8350820): OperatingSystemMXBean CpuLoad() methods return -1.0 on Windows (**Bug** - P2 - Approved)


### Reviewers
 * [Kevin Walls](https://openjdk.org/census#kevinw) (@kevinjwalls - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk24u.git pull/103/head:pull/103` \
`$ git checkout pull/103`

Update a local copy of the PR: \
`$ git checkout pull/103` \
`$ git pull https://git.openjdk.org/jdk24u.git pull/103/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 103`

View PR using the GUI difftool: \
`$ git pr show -t 103`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk24u/pull/103.diff">https://git.openjdk.org/jdk24u/pull/103.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk24u/pull/103#issuecomment-2696646349)
</details>
