### PR TITLE
8344581: [TESTBUG] java/awt/Robot/ScreenCaptureRobotTest.java failing on macOS

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -468,7 +468,6 @@ java/awt/Window/MainKeyWindowTest/TestMainKeyWindow.java 8265985 macosx-all
 java/awt/Robot/Delay/InterruptOfDelay.java 8265986 macosx-all
 java/awt/Robot/InfiniteLoopException.java 8342638 windows-all,linux-all
 java/awt/MenuBar/TestNoScreenMenuBar.java 8265987 macosx-all
-java/awt/Robot/ScreenCaptureRobotTest.java 8344581 macosx-all
 
 java/awt/Graphics2D/DrawString/DrawRotatedStringUsingRotatedFont.java 8266283 generic-all
 java/awt/Graphics2D/DrawString/RotTransText.java 8316878 linux-all

--- a/test/jdk/java/awt/Robot/ScreenCaptureRobotTest.java
+++ b/test/jdk/java/awt/Robot/ScreenCaptureRobotTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -44,6 +44,17 @@ import javax.imageio.ImageIO;
  * @bug 8342098
  * @summary Verify that the image captured from the screen using a Robot
  * and the source image are same.
+ * @requires os.family == "mac"
+ * @run main/othervm ScreenCaptureRobotTest
+ */
+
+/*
+ * @test
+ * @key headful
+ * @bug 8342098
+ * @summary Verify that the image captured from the screen using a Robot
+ * and the source image are same.
+ * @requires os.family != "mac"
  * @run main/othervm -Dsun.java2d.uiScale=1 ScreenCaptureRobotTest
  */
 public class ScreenCaptureRobotTest {
@@ -96,6 +107,7 @@ public class ScreenCaptureRobotTest {
 
     private static void doTest() throws Exception {
         Robot robot = new Robot();
+        robot.mouseMove(0, 0);
         robot.waitForIdle();
         robot.delay(500);
 


### PR DESCRIPTION
Improve the 'java/awt/Robot/ScreenCaptureRobotTest.java' to cover the MacOS failure scenarios.

This pull request contains a backport of commit [e4c22a4](https://git.openjdk.org/jdk/commit/0d30b869d8be831bfc5ff5511b3a42900e4c22a4) 
from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8344581](https://bugs.openjdk.org/browse/JDK-8344581) needs maintainer approval

### Issue
 * [JDK-8344581](https://bugs.openjdk.org/browse/JDK-8344581): [TESTBUG] java/awt/Robot/ScreenCaptureRobotTest.java failing on macOS (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk24u.git pull/106/head:pull/106` \
`$ git checkout pull/106`

Update a local copy of the PR: \
`$ git checkout pull/106` \
`$ git pull https://git.openjdk.org/jdk24u.git pull/106/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 106`

View PR using the GUI difftool: \
`$ git pr show -t 106`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk24u/pull/106.diff">https://git.openjdk.org/jdk24u/pull/106.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk24u/pull/106#issuecomment-2697595905)
</details>
