### PR TITLE
8342775: [Graal] java/util/concurrent/locks/Lock/OOMEInAQS.java fails OOME  thrown from the UncaughtExceptionHandler

### DIFF
--- a/test/jdk/java/util/concurrent/locks/Lock/OOMEInAQS.java
+++ b/test/jdk/java/util/concurrent/locks/Lock/OOMEInAQS.java
@@ -39,6 +39,7 @@ import java.util.stream.Stream;
  * @bug 8066859
  * @summary Check that AQS-based locks, conditions, and CountDownLatches do not fail when encountering OOME
  * @requires vm.gc.G1
+ * @requires !(vm.graal.enabled & vm.compMode == "Xcomp")
  * @run main/othervm -XX:+UseG1GC -XX:-UseGCOverheadLimit -Xmx48M -XX:-UseTLAB OOMEInAQS
  */
 

--- a/test/jdk/java/util/concurrent/locks/StampedLock/OOMEInStampedLock.java
+++ b/test/jdk/java/util/concurrent/locks/StampedLock/OOMEInStampedLock.java
@@ -38,6 +38,7 @@ import java.util.stream.Stream;
  * @bug 8066859
  * @summary An adaptation of OOMEInAQS test for StampedLocks
  * @requires vm.gc.G1
+ * @requires !(vm.graal.enabled & vm.compMode == "Xcomp")
  * @run main/othervm -XX:+UseG1GC -XX:-UseGCOverheadLimit -Xmx48M -XX:-UseTLAB OOMEInStampedLock
  */
 


### PR DESCRIPTION
8342775: [Graal] java/util/concurrent/locks/Lock/OOMEInAQS.java fails OOME thrown from the UncaughtExceptionHandler

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8342775](https://bugs.openjdk.org/browse/JDK-8342775) needs maintainer approval

### Issue
 * [JDK-8342775](https://bugs.openjdk.org/browse/JDK-8342775): [Graal] java/util/concurrent/locks/Lock/OOMEInAQS.java fails OOME  thrown from the UncaughtExceptionHandler (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk24u.git pull/108/head:pull/108` \
`$ git checkout pull/108`

Update a local copy of the PR: \
`$ git checkout pull/108` \
`$ git pull https://git.openjdk.org/jdk24u.git pull/108/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 108`

View PR using the GUI difftool: \
`$ git pr show -t 108`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk24u/pull/108.diff">https://git.openjdk.org/jdk24u/pull/108.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk24u/pull/108#issuecomment-2700152796)
</details>
