### PR TITLE
8349213: G1: Clearing bitmaps during collection set merging not claimed by region

### DIFF
--- a/src/hotspot/share/gc/g1/g1RemSet.cpp
+++ b/src/hotspot/share/gc/g1/g1RemSet.cpp
@@ -1161,22 +1161,6 @@ class G1MergeHeapRootsTask : public WorkerTask {
     }
   };
 
-  // Helper to allow two closure to be applied when
-  // iterating through the collection set.
-  class G1CombinedClosure : public G1HeapRegionClosure {
-    G1HeapRegionClosure* _closure1;
-    G1HeapRegionClosure* _closure2;
-  public:
-    G1CombinedClosure(G1HeapRegionClosure* cl1, G1HeapRegionClosure* cl2) :
-      _closure1(cl1),
-      _closure2(cl2) { }
-
-    bool do_heap_region(G1HeapRegion* hr) {
-      return _closure1->do_heap_region(hr) ||
-             _closure2->do_heap_region(hr);
-    }
-  };
-
   // Visitor for the remembered sets of humongous candidate regions to merge their
   // remembered set into the card table.
   class G1FlushHumongousCandidateRemSets : public G1HeapRegionIndexClosure {
@@ -1277,6 +1261,7 @@ class G1MergeHeapRootsTask : public WorkerTask {
   };
 
   uint _num_workers;
+  G1HeapRegionClaimer _hr_claimer;
   G1RemSetScanState* _scan_state;
 
   // To mitigate contention due multiple threads accessing and popping BufferNodes from a shared
@@ -1306,6 +1291,7 @@ public:
   G1MergeHeapRootsTask(G1RemSetScanState* scan_state, uint num_workers, bool initial_evacuation) :
     WorkerTask("G1 Merge Heap Roots"),
     _num_workers(num_workers),
+    _hr_claimer(num_workers),
     _scan_state(scan_state),
     _dirty_card_buffers(nullptr),
     _initial_evacuation(initial_evacuation),
@@ -1395,20 +1381,25 @@ public:
       {
         // 2. collection set
         G1MergeCardSetClosure merge(_scan_state);
-        G1ClearBitmapClosure clear(g1h);
-        G1CombinedClosure combined(&merge, &clear);
 
         if (_initial_evacuation) {
           G1HeapRegionRemSet::iterate_for_merge(g1h->young_regions_cardset(), merge);
         }
 
-        g1h->collection_set_iterate_increment_from(&combined, nullptr, worker_id);
+        g1h->collection_set_iterate_increment_from(&merge, worker_id);
+
         G1MergeCardSetStats stats = merge.stats();
 
         for (uint i = 0; i < G1GCPhaseTimes::MergeRSContainersSentinel; i++) {
           p->record_or_add_thread_work_item(merge_remset_phase, worker_id, stats.merged(i), i);
         }
       }
+    }
+
+    // Preparation for evacuation failure handling.
+    {
+      G1ClearBitmapClosure clear(g1h);
+      g1h->collection_set_iterate_increment_from(&clear, &_hr_claimer, worker_id);
     }
 
     // Now apply the closure to all remaining log entries.


### PR DESCRIPTION
Hi all,

  This pull request contains a backport of commit [8e858294](https://github.com/openjdk/jdk/commit/8e8582949669d5f3dcb68886ccb6a719393d1a9e) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Thomas Schatzl on 11 Feb 2025 and was reviewed by Ivan Walulya and Albert Mingkun Yang.

Since this change did not apply cleanly due to changes in handling remembered sets (group remsets), it needs re-review.

Testing: gha, tier1-4

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8349213](https://bugs.openjdk.org/browse/JDK-8349213) needs maintainer approval

### Issue
 * [JDK-8349213](https://bugs.openjdk.org/browse/JDK-8349213): G1: Clearing bitmaps during collection set merging not claimed by region (**Bug** - P4 - Approved)


### Reviewers
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk24u.git pull/109/head:pull/109` \
`$ git checkout pull/109`

Update a local copy of the PR: \
`$ git checkout pull/109` \
`$ git pull https://git.openjdk.org/jdk24u.git pull/109/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 109`

View PR using the GUI difftool: \
`$ git pr show -t 109`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk24u/pull/109.diff">https://git.openjdk.org/jdk24u/pull/109.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk24u/pull/109#issuecomment-2704172830)
</details>
