### PR TITLE
8350546: Several java/net/InetAddress tests fails UnknownHostException

### DIFF
--- a/test/jdk/java/net/InetAddress/IsReachableViaLoopbackTest.java
+++ b/test/jdk/java/net/InetAddress/IsReachableViaLoopbackTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,22 +21,24 @@
  * questions.
  */
 
-import java.io.*;
-import java.net.*;
-import java.util.*;
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.NetworkInterface;
 
 /**
  * @test
  * @bug 8135305
  * @key intermittent
+ * @library /test/lib
  * @summary ensure we can't ping external hosts via loopback if
+ * @run main IsReachableViaLoopbackTest
  */
 
 public class IsReachableViaLoopbackTest {
     public static void main(String[] args) {
         try {
-            InetAddress addr = InetAddress.getByName("localhost");
-            InetAddress remoteAddr = InetAddress.getByName("bugs.openjdk.org");
+            InetAddress addr = InetAddress.getLoopbackAddress();
+            InetAddress remoteAddr = InetAddress.getByName("23.197.138.208");  // use literal address to avoid DNS checks
             if (!addr.isReachable(10000))
                 throw new RuntimeException("Localhost should always be reachable");
             NetworkInterface inf = NetworkInterface.getByInetAddress(addr);
@@ -54,7 +56,6 @@ public class IsReachableViaLoopbackTest {
             } else {
                 System.out.println("inf == null");
             }
-
         } catch (IOException e) {
             throw new RuntimeException("Unexpected exception:" + e);
         }

--- a/test/jdk/java/net/InetAddress/getOriginalHostName.java
+++ b/test/jdk/java/net/InetAddress/getOriginalHostName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -41,7 +41,9 @@ public class getOriginalHostName {
     public static void main(String[] args) throws Exception {
         final String HOST = "dummyserver.java.net";
         InetAddress ia = null;
-        ia = InetAddress.getByName(HOST);
+        ia = getInetAddress(HOST);
+        if (ia != null) testInetAddress(ia, HOST);
+        ia = InetAddress.getByAddress(HOST, new byte[] { 1, 2, 3, 4});
         testInetAddress(ia, HOST);
         ia = InetAddress.getByName("255.255.255.0");
         testInetAddress(ia, null);
@@ -53,6 +55,14 @@ public class getOriginalHostName {
         testInetAddress(ia, ia.getHostName());
     }
 
+    private static InetAddress getInetAddress(String host) {
+        try {
+            return InetAddress.getByName(host);
+        } catch (java.net.UnknownHostException uhe) {
+            System.out.println("Skipping " + host + " due to " + uhe);
+            return null;
+        }
+    }
 
     private static void testInetAddress(InetAddress ia, String expected)
         throws Exception {


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [caaf4098](https://github.com/openjdk/jdk/commit/caaf4098452476d981183ad4302b76b9c883a72b) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by SendaoYan on 5 Mar 2025 and was reviewed by Daniel Fuchs and Mikhail Yankelevich.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8350546](https://bugs.openjdk.org/browse/JDK-8350546) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8350546](https://bugs.openjdk.org/browse/JDK-8350546): Several java/net/InetAddress tests fails UnknownHostException (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk24u.git pull/110/head:pull/110` \
`$ git checkout pull/110`

Update a local copy of the PR: \
`$ git checkout pull/110` \
`$ git pull https://git.openjdk.org/jdk24u.git pull/110/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 110`

View PR using the GUI difftool: \
`$ git pr show -t 110`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk24u/pull/110.diff">https://git.openjdk.org/jdk24u/pull/110.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk24u/pull/110#issuecomment-2700878203)
</details>
