### PR TITLE
8342524: Use latch in AbstractButton/bug6298940.java instead of delay

### DIFF
--- a/test/jdk/javax/swing/AbstractButton/bug6298940.java
+++ b/test/jdk/javax/swing/AbstractButton/bug6298940.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2005, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 6298940
+ * @key headful
+ * @summary Tests that mnemonic keystroke fires an action
+ * @library /javax/swing/regtesthelpers
+ * @build Util
+ * @run main bug6298940
+ */
+
+import java.awt.Robot;
+import java.awt.event.KeyEvent;
+import java.util.concurrent.CountDownLatch;
+
+import javax.swing.ButtonModel;
+import javax.swing.DefaultButtonModel;
+import javax.swing.JButton;
+import javax.swing.JFrame;
+import javax.swing.SwingUtilities;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+public final class bug6298940 {
+    private static JFrame frame;
+
+    private static final CountDownLatch actionEvent = new CountDownLatch(1);
+
+    private static void createAndShowGUI() {
+        ButtonModel model = new DefaultButtonModel();
+        model.addActionListener(event -> {
+            System.out.println("ActionEvent");
+            actionEvent.countDown();
+        });
+        model.setMnemonic('T');
+
+        JButton button = new JButton("Test");
+        button.setModel(model);
+
+        frame = new JFrame("bug6298940");
+        frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
+        frame.add(button);
+        frame.pack();
+        frame.setLocationRelativeTo(null);
+        frame.setVisible(true);
+        frame.toFront();
+    }
+
+    public static void main(String[] args) throws Exception {
+        Robot robot = new Robot();
+
+        SwingUtilities.invokeAndWait(bug6298940::createAndShowGUI);
+
+        robot.waitForIdle();
+        robot.delay(500);
+
+        Util.hitMnemonics(robot, KeyEvent.VK_T);
+
+        try {
+            if (!actionEvent.await(1, SECONDS)) {
+                throw new RuntimeException("Mnemonic didn't fire an action");
+            }
+        } finally {
+            SwingUtilities.invokeAndWait(() -> {
+                if (frame != null) {
+                    frame.dispose();
+                }
+            });
+        }
+    }
+}


### PR DESCRIPTION
This pull request contains a backport of commit [2bd8f026](https://github.com/openjdk/jdk/commit/2bd8f026dbd449e810dc6ce96cd9235e5cb51a9b) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Alexey Ivanov on 17 Feb 2025 and was reviewed by Alexander Zvegintsev, Alexander Zuev, Damon Nguyen and Alisen Chung.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8342524](https://bugs.openjdk.org/browse/JDK-8342524) needs maintainer approval

### Issue
 * [JDK-8342524](https://bugs.openjdk.org/browse/JDK-8342524): Use latch in AbstractButton/bug6298940.java instead of delay (**Bug** - P5 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk24u.git pull/112/head:pull/112` \
`$ git checkout pull/112`

Update a local copy of the PR: \
`$ git checkout pull/112` \
`$ git pull https://git.openjdk.org/jdk24u.git pull/112/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 112`

View PR using the GUI difftool: \
`$ git pr show -t 112`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk24u/pull/112.diff">https://git.openjdk.org/jdk24u/pull/112.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk24u/pull/112#issuecomment-2701542034)
</details>
