### PR TITLE
8351223: Update localized resources in keytool and jarsigner

### DIFF
--- a/src/java.base/share/classes/sun/security/tools/keytool/Resources_de.java
+++ b/src/java.base/share/classes/sun/security/tools/keytool/Resources_de.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -304,10 +304,12 @@ public class Resources_de extends java.util.ListResourceBundle {
                 "Das Angeben von -keysize zum Generieren von EC-Schl\u00FCsseln ist veraltet. Verwenden Sie stattdessen \"-groupname %s\"."},
         {"Key.pair.not.generated.alias.alias.already.exists",
                 "Schl\u00FCsselpaar wurde nicht generiert. Alias <{0}> ist bereits vorhanden"},
-        {"Generating.keysize.bit.keyAlgName.key.pair.and.self.signed.certificate.sigAlgName.with.a.validity.of.validality.days.for",
-                "Generieren von Schl\u00FCsselpaar (Typ {1}, {0} Bit) und selbst signiertem Zertifikat ({2}) mit einer G\u00FCltigkeit von {3} Tagen\n\tf\u00FCr: {4}"},
-        {"Generating.keysize.bit.keyAlgName.key.pair.and.a.certificate.sigAlgName.issued.by.signerAlias.with.a.validity.of.validality.days.for",
-                "Generieren von Schl\u00FCsselpaar (Typ {1}, {0} Bit) und Zertifikat ({2}), ausgestellt von <{3}>, mit einer G\u00FCltigkeit von {4} Tagen\n\tf\u00FCr: {5}"},
+        {"size.bit.alg",
+                "%1$d-Bit %2$s"},
+        {"Generating.full.keyAlgName.key.pair.and.self.signed.certificate.sigAlgName.with.a.validity.of.days.for",
+                "Schl\u00FCsselpaar {0} und selbstsigniertes Zertifikat ({1}) werden mit einer G\u00FCltigkeit von {2} Tagen generiert\n\tf\u00FCr: {3}"},
+        {"Generating.full.keyAlgName.key.pair.and.a.certificate.sigAlgName.issued.by.signerAlias.with.a.validity.of.days.for",
+                "Schl\u00FCsselpaar {0} und Zertifikat ({1}) werden generiert, das von <{2}> mit einer G\u00FCltigkeit von {3} Tagen ausgestellt wurde\n\tf\u00FCr: {4}"},
         {"Enter.key.password.for.alias.", "Schl\u00FCsselkennwort f\u00FCr <{0}> eingeben"},
         {".RETURN.if.same.as.keystore.password.",
                 "\t(RETURN, wenn identisch mit Keystore-Kennwort):  "},
@@ -472,10 +474,9 @@ public class Resources_de extends java.util.ListResourceBundle {
         {"alias.in.keystore", "Aussteller <%s>"},
         {"with.weak", "%s (schwach)"},
         {"with.disabled", "%s (deaktiviert)"},
-        {"key.bit", "%1$d-Bit-%2$s-Schl\u00FCssel"},
-        {"key.bit.weak", "%1$d-Bit-%2$s-Schl\u00FCssel (schwach)"},
-        {"key.bit.disabled", "%1$d-Bit-%2$s-Schl\u00FCssel (deaktiviert)"},
-        {"unknown.size.1", "%s-Schl\u00FCssel mit unbekannter Gr\u00F6\u00DFe"},
+        {"key.bit", "%s-Schl\u00FCssel"},
+        {"key.bit.weak", "%s Schl\u00FCssel (schwach)"},
+        {"key.bit.disabled", "%s Schl\u00FCssel (deaktiviert)"},
         {".PATTERN.printX509Cert.with.weak",
                 "Eigent\u00FCmer: {0}\nAussteller: {1}\nSeriennummer: {2}\nG\u00FCltig von: {3} bis: {4}\nZertifikatsfingerprints:\n\t SHA1: {5}\n\t SHA256: {6}\nSignaturalgorithmusname: {7}\nPublic-Key-Algorithmus von Subject: {8}\nVersion: {9}"},
         {"PKCS.10.with.weak",
@@ -486,7 +487,7 @@ public class Resources_de extends java.util.ListResourceBundle {
         {"Unable.to.parse.denyAfter.string.in.exception.message", "denyAfter-Datumszeichenfolge in Ausnahmemeldung kann nicht geparst werden"},
         {"whose.sigalg.weak", "%1$s verwendet den Signaturalgorithmus %2$s. Dies gilt als Sicherheitsrisiko."},
         {"whose.key.disabled", "%1$s verwendet %2$s. Dies gilt als Sicherheitsrisiko und ist deaktiviert."},
-        {"whose.key.weak", "%1$s verwendet %2$s. Dies gilt als Sicherheitsrisiko. Diese Schl\u00FCsselgr\u00F6\u00DFe wird in einem zuk\u00FCnftigen Update deaktiviert."},
+        {"whose.key.weak", "%1$s verwendet %2$s. Dies gilt als Sicherheitsrisiko. Wird in einem zuk\u00FCnftigen Update deaktiviert."},
         {"jks.storetype.warning", "Der %1$s-Keystore verwendet ein propriet\u00E4res Format. Es wird empfohlen, auf PKCS12 zu migrieren, das ein Industriestandardformat mit \"keytool -importkeystore -srckeystore %2$s -destkeystore %2$s -deststoretype pkcs12\" ist."},
         {"migrate.keystore.warning", "\"%1$s\" zu %4$s migriert. Der %2$s-Keystore wurde als \"%3$s\" gesichert."},
         {"backup.keystore.warning", "Der urspr\u00FCngliche Keystore \"%1$s\" wird als \"%3$s\" gesichert..."},

--- a/src/java.base/share/classes/sun/security/tools/keytool/Resources_ja.java
+++ b/src/java.base/share/classes/sun/security/tools/keytool/Resources_ja.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -304,10 +304,12 @@ public class Resources_ja extends java.util.ListResourceBundle {
                 "-keysize\u306E\u6307\u5B9A\u306B\u3088\u308BEC\u30AD\u30FC\u306E\u751F\u6210\u306F\u975E\u63A8\u5968\u3067\u3059\u3002\u304B\u308F\u308A\u306B\"-groupname %s\"\u3092\u4F7F\u7528\u3057\u3066\u304F\u3060\u3055\u3044\u3002"},
         {"Key.pair.not.generated.alias.alias.already.exists",
                 "\u30AD\u30FC\u30FB\u30DA\u30A2\u306F\u751F\u6210\u3055\u308C\u307E\u305B\u3093\u3067\u3057\u305F\u3002\u5225\u540D<{0}>\u306F\u3059\u3067\u306B\u5B58\u5728\u3057\u307E\u3059"},
-        {"Generating.keysize.bit.keyAlgName.key.pair.and.self.signed.certificate.sigAlgName.with.a.validity.of.validality.days.for",
-                "{3}\u65E5\u9593\u6709\u52B9\u306A{0}\u30D3\u30C3\u30C8\u306E{1}\u306E\u30AD\u30FC\u30FB\u30DA\u30A2\u3068\u81EA\u5DF1\u7F72\u540D\u578B\u8A3C\u660E\u66F8({2})\u3092\u751F\u6210\u3057\u3066\u3044\u307E\u3059\n\t\u30C7\u30A3\u30EC\u30AF\u30C8\u30EA\u540D: {4}"},
-        {"Generating.keysize.bit.keyAlgName.key.pair.and.a.certificate.sigAlgName.issued.by.signerAlias.with.a.validity.of.validality.days.for",
-                "{4}\u65E5\u9593\u6709\u52B9\u306A{0}\u30D3\u30C3\u30C8\u306E{1}\u30AD\u30FC\u30FB\u30DA\u30A2\u3068<{3}>\u306B\u3088\u3063\u3066\u767A\u884C\u3055\u308C\u308B\u8A3C\u660E\u66F8({2})\u3092\u751F\u6210\u3057\u3066\u3044\u307E\u3059\n\t\u30C7\u30A3\u30EC\u30AF\u30C8\u30EA\u540D: {5}"},
+        {"size.bit.alg",
+                "%1$d\u30D3\u30C3\u30C8%2$s"},
+        {"Generating.full.keyAlgName.key.pair.and.self.signed.certificate.sigAlgName.with.a.validity.of.days.for",
+                "{0}\u30AD\u30FC\u30FB\u30DA\u30A2\u304A\u3088\u3073\u81EA\u5DF1\u7F72\u540D\u8A3C\u660E\u66F8({1})\u3092{2}\u65E5\u306E\u6709\u52B9\u6027\u3067\u751F\u6210\u3057\u3066\u3044\u307E\u3059\n\t\u5BFE\u8C61: {3}"},
+        {"Generating.full.keyAlgName.key.pair.and.a.certificate.sigAlgName.issued.by.signerAlias.with.a.validity.of.days.for",
+                "{0}\u30AD\u30FC\u30FB\u30DA\u30A2\u3068\u003C\u007B\u0032\u007D\u003E\u306B\u3088\u3063\u3066\u767A\u884C\u3055\u308C\u305F\u8A3C\u660E\u66F8({1})\u3092{3}\u65E5\u9593\u306E\u6709\u52B9\u6027\u3067\u751F\u6210\u3057\u3066\u3044\u307E\u3059\n\t\u5BFE\u8C61: {4}"},
         {"Enter.key.password.for.alias.", "<{0}>\u306E\u30AD\u30FC\u30FB\u30D1\u30B9\u30EF\u30FC\u30C9\u3092\u5165\u529B\u3057\u3066\u304F\u3060\u3055\u3044"},
         {".RETURN.if.same.as.keystore.password.",
                 "\t(\u30AD\u30FC\u30B9\u30C8\u30A2\u306E\u30D1\u30B9\u30EF\u30FC\u30C9\u3068\u540C\u3058\u5834\u5408\u306FRETURN\u3092\u62BC\u3057\u3066\u304F\u3060\u3055\u3044):  "},
@@ -472,10 +474,9 @@ public class Resources_ja extends java.util.ListResourceBundle {
         {"alias.in.keystore", "\u767A\u884C\u8005<%s>"},
         {"with.weak", "%s (\u5F31)"},
         {"with.disabled", "%s (\u7121\u52B9)"},
-        {"key.bit", "%1$d\u30D3\u30C3\u30C8%2$s\u30AD\u30FC"},
-        {"key.bit.weak", "%1$d\u30D3\u30C3\u30C8%2$s\u30AD\u30FC(\u5F31)"},
-        {"key.bit.disabled", "%1$d-bit %2$s key (\u7121\u52B9)"},
-        {"unknown.size.1", "\u4E0D\u660E\u306A\u30B5\u30A4\u30BA\u306E%s\u30AD\u30FC"},
+        {"key.bit", "%s\u30AD\u30FC"},
+        {"key.bit.weak", "%s\u30AD\u30FC(\u5F31\u3044)"},
+        {"key.bit.disabled", "%s\u30AD\u30FC(\u7121\u52B9)"},
         {".PATTERN.printX509Cert.with.weak",
                 "\u6240\u6709\u8005: {0}\n\u767A\u884C\u8005: {1}\n\u30B7\u30EA\u30A2\u30EB\u756A\u53F7: {2}\n\u6709\u52B9\u671F\u9593\u306E\u958B\u59CB\u65E5: {3}\u7D42\u4E86\u65E5: {4}\n\u8A3C\u660E\u66F8\u306E\u30D5\u30A3\u30F3\u30AC\u30D7\u30EA\u30F3\u30C8:\n\t SHA1: {5}\n\t SHA256: {6}\n\u7F72\u540D\u30A2\u30EB\u30B4\u30EA\u30BA\u30E0\u540D: {7}\n\u30B5\u30D6\u30B8\u30A7\u30AF\u30C8\u516C\u958B\u30AD\u30FC\u30FB\u30A2\u30EB\u30B4\u30EA\u30BA\u30E0: {8}\n\u30D0\u30FC\u30B8\u30E7\u30F3: {9}"},
         {"PKCS.10.with.weak",
@@ -486,7 +487,7 @@ public class Resources_ja extends java.util.ListResourceBundle {
         {"Unable.to.parse.denyAfter.string.in.exception.message", "\u4F8B\u5916\u30E1\u30C3\u30BB\u30FC\u30B8\u306EdenyAfter\u65E5\u4ED8\u6587\u5B57\u5217\u3092\u89E3\u6790\u3067\u304D\u307E\u305B\u3093"},
         {"whose.sigalg.weak", "%1$s\u306F%2$s\u7F72\u540D\u30A2\u30EB\u30B4\u30EA\u30BA\u30E0\u3092\u4F7F\u7528\u3057\u3066\u304A\u308A\u3001\u3053\u308C\u306F\u30BB\u30AD\u30E5\u30EA\u30C6\u30A3\u30FB\u30EA\u30B9\u30AF\u3068\u307F\u306A\u3055\u308C\u307E\u3059\u3002"},
         {"whose.key.disabled", "%1$s\u306F%2$s\u3092\u4F7F\u7528\u3057\u3066\u304A\u308A\u3001\u3053\u308C\u306F\u30BB\u30AD\u30E5\u30EA\u30C6\u30A3\u30FB\u30EA\u30B9\u30AF\u3068\u307F\u306A\u3055\u308C\u3001\u7121\u52B9\u5316\u3055\u308C\u3066\u3044\u307E\u3059\u3002"},
-        {"whose.key.weak", "%1$s\u306F%2$s\u3092\u4F7F\u7528\u3057\u3066\u304A\u308A\u3001\u3053\u308C\u306F\u30BB\u30AD\u30E5\u30EA\u30C6\u30A3\u30FB\u30EA\u30B9\u30AF\u3068\u307F\u306A\u3055\u308C\u307E\u3059\u3002\u3053\u306E\u30AD\u30FC\u30FB\u30B5\u30A4\u30BA\u306F\u5C06\u6765\u306E\u66F4\u65B0\u3067\u7121\u52B9\u5316\u3055\u308C\u307E\u3059\u3002"},
+        {"whose.key.weak", "%1$s\u306F%2$s\u3092\u4F7F\u7528\u3057\u3066\u304A\u308A\u3001\u3053\u308C\u306F\u30BB\u30AD\u30E5\u30EA\u30C6\u30A3\u30FB\u30EA\u30B9\u30AF\u3068\u307F\u306A\u3055\u308C\u307E\u3059\u3002\u4ECA\u5F8C\u306E\u66F4\u65B0\u3067\u306F\u7121\u52B9\u306B\u306A\u308A\u307E\u3059\u3002"},
         {"jks.storetype.warning", "%1$s\u30AD\u30FC\u30B9\u30C8\u30A2\u306F\u72EC\u81EA\u306E\u5F62\u5F0F\u3092\u4F7F\u7528\u3057\u3066\u3044\u307E\u3059\u3002\"keytool -importkeystore -srckeystore %2$s -destkeystore %2$s -deststoretype pkcs12\"\u3092\u4F7F\u7528\u3059\u308B\u696D\u754C\u6A19\u6E96\u306E\u5F62\u5F0F\u3067\u3042\u308BPKCS12\u306B\u79FB\u884C\u3059\u308B\u3053\u3068\u3092\u304A\u85A6\u3081\u3057\u307E\u3059\u3002"},
         {"migrate.keystore.warning", "\"%1$s\"\u304C%4$s\u306B\u79FB\u884C\u3055\u308C\u307E\u3057\u305F\u3002%2$s\u30AD\u30FC\u30B9\u30C8\u30A2\u306F\"%3$s\"\u3068\u3057\u3066\u30D0\u30C3\u30AF\u30A2\u30C3\u30D7\u3055\u308C\u307E\u3059\u3002"},
         {"backup.keystore.warning", "\u5143\u306E\u30AD\u30FC\u30B9\u30C8\u30A2\"%1$s\"\u306F\"%3$s\"\u3068\u3057\u3066\u30D0\u30C3\u30AF\u30A2\u30C3\u30D7\u3055\u308C\u307E\u3059..."},

--- a/src/java.base/share/classes/sun/security/tools/keytool/Resources_zh_CN.java
+++ b/src/java.base/share/classes/sun/security/tools/keytool/Resources_zh_CN.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -304,10 +304,12 @@ public class Resources_zh_CN extends java.util.ListResourceBundle {
                 "\u4E3A\u751F\u6210 EC \u5BC6\u94A5\u6307\u5B9A -keysize \u5DF2\u8FC7\u65F6\uFF0C\u8BF7\u6539\u4E3A\u4F7F\u7528 \"-groupname %s\"\u3002"},
         {"Key.pair.not.generated.alias.alias.already.exists",
                 "\u672A\u751F\u6210\u5BC6\u94A5\u5BF9, \u522B\u540D <{0}> \u5DF2\u7ECF\u5B58\u5728"},
-        {"Generating.keysize.bit.keyAlgName.key.pair.and.self.signed.certificate.sigAlgName.with.a.validity.of.validality.days.for",
-                "\u6B63\u5728\u4E3A\u4EE5\u4E0B\u5BF9\u8C61\u751F\u6210 {0} \u4F4D{1}\u5BC6\u94A5\u5BF9\u548C\u81EA\u7B7E\u540D\u8BC1\u4E66 ({2}) (\u6709\u6548\u671F\u4E3A {3} \u5929):\n\t {4}"},
-        {"Generating.keysize.bit.keyAlgName.key.pair.and.a.certificate.sigAlgName.issued.by.signerAlias.with.a.validity.of.validality.days.for",
-                "\u6B63\u5728\u4E3A\u4EE5\u4E0B\u5BF9\u8C61\u751F\u6210 {0} \u4F4D {1} \u5BC6\u94A5\u5BF9\u548C\u7531 <{3}> \u9881\u53D1\u7684\u8BC1\u4E66 ({2})\uFF08\u6709\u6548\u671F\u4E3A {4} \u5929\uFF09\uFF1A\n\t {5}"},
+        {"size.bit.alg",
+                "%1$d \u4F4D %2$s"},
+        {"Generating.full.keyAlgName.key.pair.and.self.signed.certificate.sigAlgName.with.a.validity.of.days.for",
+                "\u6B63\u5728\u4E3A {3} \u751F\u6210\u6709\u6548\u671F\u4E3A {2} \u5929\u7684 {0} \u5BC6\u94A5\u5BF9\u548C\u81EA\u7B7E\u540D\u8BC1\u4E66 ({1})\n"},
+        {"Generating.full.keyAlgName.key.pair.and.a.certificate.sigAlgName.issued.by.signerAlias.with.a.validity.of.days.for",
+                "\u751F\u6210 {0} \u5BC6\u94A5\u5BF9\u548C <{2}> \u9881\u53D1\u7684\u8BC1\u4E66 ({1})\uFF0C\u6709\u6548\u671F\u4E3A {3} \u5929 \n\t \u5BF9\u4E8E\uFF1A{4}"},
         {"Enter.key.password.for.alias.", "\u8F93\u5165 <{0}> \u7684\u5BC6\u94A5\u53E3\u4EE4"},
         {".RETURN.if.same.as.keystore.password.",
                 "\t(\u5982\u679C\u548C\u5BC6\u94A5\u5E93\u53E3\u4EE4\u76F8\u540C, \u6309\u56DE\u8F66):  "},
@@ -472,10 +474,9 @@ public class Resources_zh_CN extends java.util.ListResourceBundle {
         {"alias.in.keystore", "\u53D1\u5E03\u8005 <%s>"},
         {"with.weak", "%s (\u5F31)"},
         {"with.disabled", "%s\uFF08\u7981\u7528\uFF09"},
-        {"key.bit", "%1$d \u4F4D %2$s \u5BC6\u94A5"},
-        {"key.bit.weak", "%1$d \u4F4D %2$s \u5BC6\u94A5 (\u5F31)"},
-        {"key.bit.disabled", "%1$d \u4F4D %2$s \u5BC6\u94A5\uFF08\u7981\u7528\uFF09"},
-        {"unknown.size.1", "\u672A\u77E5\u5927\u5C0F\u7684 %s \u5BC6\u94A5"},
+        {"key.bit", "%s \u5BC6\u94A5"},
+        {"key.bit.weak", "%s \u5BC6\u94A5\uFF08\u5F31\uFF09"},
+        {"key.bit.disabled", "%s \u5BC6\u94A5\uFF08\u5DF2\u7981\u7528\uFF09"},
         {".PATTERN.printX509Cert.with.weak",
                 "\u6240\u6709\u8005: {0}\n\u53D1\u5E03\u8005: {1}\n\u5E8F\u5217\u53F7: {2}\n\u751F\u6548\u65F6\u95F4: {3}, \u5931\u6548\u65F6\u95F4: {4}\n\u8BC1\u4E66\u6307\u7EB9:\n\t SHA1: {5}\n\t SHA256: {6}\n\u7B7E\u540D\u7B97\u6CD5\u540D\u79F0: {7}\n\u4E3B\u4F53\u516C\u5171\u5BC6\u94A5\u7B97\u6CD5: {8}\n\u7248\u672C: {9}"},
         {"PKCS.10.with.weak",
@@ -486,7 +487,7 @@ public class Resources_zh_CN extends java.util.ListResourceBundle {
         {"Unable.to.parse.denyAfter.string.in.exception.message", "\u65E0\u6CD5\u89E3\u6790\u5F02\u5E38\u9519\u8BEF\u6D88\u606F\u4E2D\u7684 denyAfter \u65E5\u671F\u5B57\u7B26\u4E32"},
         {"whose.sigalg.weak", "%1$s \u4F7F\u7528\u7684 %2$s \u7B7E\u540D\u7B97\u6CD5\u5B58\u5728\u5B89\u5168\u98CE\u9669\u3002"},
         {"whose.key.disabled", "%1$s \u4F7F\u7528\u7684 %2$s \u88AB\u89C6\u4E3A\u5B58\u5728\u5B89\u5168\u98CE\u9669\u800C\u4E14\u88AB\u7981\u7528\u3002"},
-        {"whose.key.weak", "%1$s \u4F7F\u7528\u7684 %2$s \u88AB\u89C6\u4E3A\u5B58\u5728\u5B89\u5168\u98CE\u9669\u3002\u6B64\u5BC6\u94A5\u5927\u5C0F\u5C06\u5728\u672A\u6765\u7684\u66F4\u65B0\u4E2D\u88AB\u7981\u7528\u3002"},
+        {"whose.key.weak", "%1$s \u4F7F\u7528\u7684 %2$s \u88AB\u89C6\u4E3A\u5B58\u5728\u5B89\u5168\u98CE\u9669\u3002\u5728\u5C06\u6765\u7684\u66F4\u65B0\u4E2D\u5C06\u7981\u7528\u5B83\u3002"},
         {"jks.storetype.warning", "%1$s \u5BC6\u94A5\u5E93\u4F7F\u7528\u4E13\u7528\u683C\u5F0F\u3002\u5EFA\u8BAE\u4F7F\u7528 \"keytool -importkeystore -srckeystore %2$s -destkeystore %2$s -deststoretype pkcs12\" \u8FC1\u79FB\u5230\u884C\u4E1A\u6807\u51C6\u683C\u5F0F PKCS12\u3002"},
         {"migrate.keystore.warning", "\u5DF2\u5C06 \"%1$s\" \u8FC1\u79FB\u5230 %4$s\u3002\u5C06 %2$s \u5BC6\u94A5\u5E93\u4F5C\u4E3A \"%3$s\" \u8FDB\u884C\u4E86\u5907\u4EFD\u3002"},
         {"backup.keystore.warning", "\u5DF2\u5C06\u539F\u59CB\u5BC6\u94A5\u5E93 \"%1$s\" \u5907\u4EFD\u4E3A \"%3$s\"..."},

--- a/src/jdk.jartool/share/classes/sun/security/tools/jarsigner/Resources_de.java
+++ b/src/jdk.jartool/share/classes/sun/security/tools/jarsigner/Resources_de.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -173,12 +173,9 @@ public class Resources_de extends java.util.ListResourceBundle {
         {"with.algparams.weak", "%1$s mit %2$s (schwach)"},
         {"with.disabled", "%s (deaktiviert)"},
         {"with.algparams.disabled", "%1$s mit %2$s (deaktiviert)"},
-        {"key.bit", "%d-Bit-Schl\u00FCssel"},
-        {"key.bit.weak", "%d-Bit-Schl\u00FCssel (schwach)"},
-        {"key.bit.eccurve.weak", "%1$d-Bit-%2$s-Schl\u00FCssel (schwach)"},
-        {"key.bit.disabled", "%d-Bit-Schl\u00FCssel (deaktiviert)"},
-        {"key.bit.eccurve.disabled", "%1$d-Bit-%2$s-Schl\u00FCssel (deaktiviert)"},
-        {"unknown.size", "unbekannte Gr\u00F6\u00DFe"},
+        {"key.bit", "%s-Schl\u00FCssel"},
+        {"key.bit.weak", "%s Schl\u00FCssel (schwach)"},
+        {"key.bit.disabled", "%s Schl\u00FCssel (deaktiviert)"},
         {"nonexistent.entries.found", "Diese JAR-Datei enth\u00E4lt signierte Eintr\u00E4ge f\u00FCr Dateien, die nicht vorhanden sind. Weitere Details finden Sie in der Verbose-Ausgabe (-verbose)."},
         {"external.file.attributes.detected", "POSIX-Dateiberechtigung und/oder Symlink-Attribute erkannt. Diese Attribute werden bei der Signatur ignoriert und sind nicht durch die Signatur gesch\u00FCtzt."},
 
@@ -295,10 +292,12 @@ public class Resources_de extends java.util.ListResourceBundle {
                 "Der %1$s-Digestalgorithmus gilt als Sicherheitsrisiko. Dieser Algorithmus wird in einem zuk\u00FCnftigen Update deaktiviert."},
         {"The.signature.algorithm.1.is.considered.a.security.risk..This.algorithm.will.be.disabled.in.a.future.update.",
                 "Der %1$s-Signaturalgorithmus gilt als Sicherheitsrisiko. Dieser Algorithmus wird in einem zuk\u00FCnftigen Update deaktiviert."},
-        {"The.1.signing.key.has.a.keysize.of.2.which.is.considered.a.security.risk..This.key.size.will.be.disabled.in.a.future.update.",
-                "Der %1$s-Signaturschl\u00FCssel hat eine Schl\u00FCsselgr\u00F6\u00DFe von %2$d. Das gilt als Sicherheitsrisiko. Diese Schl\u00FCsselgr\u00F6\u00DFe wird in einem zuk\u00FCnftigen Update deaktiviert."},
-        {"The.1.signing.key.has.a.keysize.of.2.which.is.considered.a.security.risk.and.is.disabled.",
-                "Der %1$s-Signaturschl\u00FCssel hat eine Schl\u00FCsselgr\u00F6\u00DFe von %2$d. Das gilt als Sicherheitsrisiko und ist deaktiviert."},
+        {"size.bit.alg",
+                "%1$d-Bit %2$s"},
+        {"The.full.keyAlgName.signing.key.is.considered.a.security.risk..It.will.be.disabled.in.a.future.update.",
+                "Der %s Signaturschl\u00FCssel wird als Sicherheitsrisiko betrachtet. Wird in einem zuk\u00FCnftigen Update deaktiviert."},
+        {"The.full.keyAlgName.signing.key.is.considered.a.security.risk.and.is.disabled.",
+                "Der %s Signaturschl\u00FCssel wird als Sicherheitsrisiko betrachtet und ist deaktiviert."},
         {"This.jar.contains.entries.whose.certificate.chain.is.invalid.reason.1",
                  "Diese JAR-Datei enth\u00E4lt Eintr\u00E4ge, deren Zertifikatskette ung\u00FCltig ist. Grund: %s"},
         {"This.jar.contains.entries.whose.tsa.certificate.chain.is.invalid.reason.1",

--- a/src/jdk.jartool/share/classes/sun/security/tools/jarsigner/Resources_ja.java
+++ b/src/jdk.jartool/share/classes/sun/security/tools/jarsigner/Resources_ja.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -173,12 +173,9 @@ public class Resources_ja extends java.util.ListResourceBundle {
         {"with.algparams.weak", "%2$s\u3092\u4F7F\u7528\u3057\u305F%1$s (\u5F31)"},
         {"with.disabled", "%s (\u7121\u52B9)"},
         {"with.algparams.disabled", "%2$s\u3092\u4F7F\u7528\u3057\u305F%1$s (\u7121\u52B9)"},
-        {"key.bit", "%d\u30D3\u30C3\u30C8\u30FB\u30AD\u30FC"},
-        {"key.bit.weak", "%d\u30D3\u30C3\u30C8\u30FB\u30AD\u30FC(\u5F31)"},
-        {"key.bit.eccurve.weak", "%1$d\u30D3\u30C3\u30C8%2$s\u30AD\u30FC(\u5F31)"},
-        {"key.bit.disabled", "%d\u30D3\u30C3\u30C8\u30FB\u30AD\u30FC (\u7121\u52B9)"},
-        {"key.bit.eccurve.disabled", "%1$d\u30D3\u30C3\u30C8%2$s\u30AD\u30FC(\u7121\u52B9)"},
-        {"unknown.size", "\u4E0D\u660E\u30B5\u30A4\u30BA"},
+        {"key.bit", "%s\u30AD\u30FC"},
+        {"key.bit.weak", "%s\u30AD\u30FC(\u5F31\u3044)"},
+        {"key.bit.disabled", "%s\u30AD\u30FC(\u7121\u52B9)"},
         {"nonexistent.entries.found", "\u3053\u306Ejar\u306B\u306F\u3001\u5B58\u5728\u3057\u306A\u3044\u30D5\u30A1\u30A4\u30EB\u306E\u7F72\u540D\u6E08\u30A8\u30F3\u30C8\u30EA\u304C\u542B\u307E\u308C\u307E\u3059\u3002\u8A73\u7D30\u306F\u3001-verbose\u51FA\u529B\u3092\u53C2\u7167\u3057\u3066\u304F\u3060\u3055\u3044\u3002"},
         {"external.file.attributes.detected", "POSIX\u30D5\u30A1\u30A4\u30EB\u6A29\u9650\u307E\u305F\u306Fsymlink(\u3042\u308B\u3044\u306F\u305D\u306E\u4E21\u65B9)\u306E\u5C5E\u6027\u304C\u691C\u51FA\u3055\u308C\u307E\u3057\u305F\u3002\u7F72\u540D\u4E2D\u306F\u3053\u308C\u3089\u306E\u5C5E\u6027\u306F\u7121\u8996\u3055\u308C\u3001\u7F72\u540D\u306B\u3088\u3063\u3066\u4FDD\u8B77\u3055\u308C\u307E\u305B\u3093\u3002"},
 
@@ -295,10 +292,12 @@ public class Resources_ja extends java.util.ListResourceBundle {
                 "%1$s\u30C0\u30A4\u30B8\u30A7\u30B9\u30C8\u30FB\u30A2\u30EB\u30B4\u30EA\u30BA\u30E0\u306F\u3001\u30BB\u30AD\u30E5\u30EA\u30C6\u30A3\u30FB\u30EA\u30B9\u30AF\u3068\u307F\u306A\u3055\u308C\u307E\u3059\u3002\u3053\u306E\u30A2\u30EB\u30B4\u30EA\u30BA\u30E0\u306F\u5C06\u6765\u306E\u66F4\u65B0\u3067\u7121\u52B9\u5316\u3055\u308C\u307E\u3059\u3002"},
         {"The.signature.algorithm.1.is.considered.a.security.risk..This.algorithm.will.be.disabled.in.a.future.update.",
                 "%1$s\u7F72\u540D\u30A2\u30EB\u30B4\u30EA\u30BA\u30E0\u306F\u3001\u30BB\u30AD\u30E5\u30EA\u30C6\u30A3\u30FB\u30EA\u30B9\u30AF\u3068\u307F\u306A\u3055\u308C\u307E\u3059\u3002\u3053\u306E\u30A2\u30EB\u30B4\u30EA\u30BA\u30E0\u306F\u5C06\u6765\u306E\u66F4\u65B0\u3067\u7121\u52B9\u5316\u3055\u308C\u307E\u3059\u3002"},
-        {"The.1.signing.key.has.a.keysize.of.2.which.is.considered.a.security.risk..This.key.size.will.be.disabled.in.a.future.update.",
-                "%1$s\u7F72\u540D\u30AD\u30FC\u306B\u306F%2$d\u306E\u30AD\u30FC\u30FB\u30B5\u30A4\u30BA\u304C\u3042\u308A\u3001\u3053\u308C\u306F\u30BB\u30AD\u30E5\u30EA\u30C6\u30A3\u30FB\u30EA\u30B9\u30AF\u3068\u307F\u306A\u3055\u308C\u307E\u3059\u3002\u3053\u306E\u30AD\u30FC\u30FB\u30B5\u30A4\u30BA\u306F\u5C06\u6765\u306E\u66F4\u65B0\u3067\u7121\u52B9\u5316\u3055\u308C\u307E\u3059\u3002"},
-        {"The.1.signing.key.has.a.keysize.of.2.which.is.considered.a.security.risk.and.is.disabled.",
-                "%1$s\u7F72\u540D\u30AD\u30FC\u306B\u306F%2$d\u306E\u30AD\u30FC\u30FB\u30B5\u30A4\u30BA\u304C\u3042\u308A\u3001\u3053\u308C\u306F\u30BB\u30AD\u30E5\u30EA\u30C6\u30A3\u30FB\u30EA\u30B9\u30AF\u3068\u307F\u306A\u3055\u308C\u307E\u3059\u3002"},
+        {"size.bit.alg",
+                "%1$d\u30D3\u30C3\u30C8%2$s"},
+        {"The.full.keyAlgName.signing.key.is.considered.a.security.risk..It.will.be.disabled.in.a.future.update.",
+                "%s\u7F72\u540D\u30AD\u30FC\u306F\u30BB\u30AD\u30E5\u30EA\u30C6\u30A3\u30FB\u30EA\u30B9\u30AF\u3068\u307F\u306A\u3055\u308C\u307E\u3059\u3002\u4ECA\u5F8C\u306E\u66F4\u65B0\u3067\u306F\u7121\u52B9\u306B\u306A\u308A\u307E\u3059\u3002"},
+        {"The.full.keyAlgName.signing.key.is.considered.a.security.risk.and.is.disabled.",
+                "%s\u7F72\u540D\u30AD\u30FC\u306F\u30BB\u30AD\u30E5\u30EA\u30C6\u30A3\u30FB\u30EA\u30B9\u30AF\u3068\u307F\u306A\u3055\u308C\u3001\u7121\u52B9\u306B\u306A\u3063\u3066\u3044\u307E\u3059\u3002"},
         {"This.jar.contains.entries.whose.certificate.chain.is.invalid.reason.1",
                  "\u3053\u306Ejar\u306B\u306F\u3001\u8A3C\u660E\u66F8\u30C1\u30A7\u30FC\u30F3\u304C\u7121\u52B9\u306A\u30A8\u30F3\u30C8\u30EA\u304C\u542B\u307E\u308C\u3066\u3044\u307E\u3059\u3002\u7406\u7531: %s"},
         {"This.jar.contains.entries.whose.tsa.certificate.chain.is.invalid.reason.1",

--- a/src/jdk.jartool/share/classes/sun/security/tools/jarsigner/Resources_zh_CN.java
+++ b/src/jdk.jartool/share/classes/sun/security/tools/jarsigner/Resources_zh_CN.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -173,12 +173,9 @@ public class Resources_zh_CN extends java.util.ListResourceBundle {
         {"with.algparams.weak", "%1$s \u4F7F\u7528 %2$s\uFF08\u5F31\uFF09"},
         {"with.disabled", "%s\uFF08\u7981\u7528\uFF09"},
         {"with.algparams.disabled", "%1$s \u4F7F\u7528 %2$s\uFF08\u7981\u7528\uFF09"},
-        {"key.bit", "%d \u4F4D\u5BC6\u94A5"},
-        {"key.bit.weak", "%d \u4F4D\u5BC6\u94A5 (\u5F31)"},
-        {"key.bit.eccurve.weak", "%1$d \u4F4D %2$s \u5BC6\u94A5 (\u5F31)"},
-        {"key.bit.disabled", "%d \u4F4D\u5BC6\u94A5\uFF08\u7981\u7528\uFF09"},
-        {"key.bit.eccurve.disabled", "%1$d \u4F4D %2$s \u5BC6\u94A5\uFF08\u7981\u7528\uFF09"},
-        {"unknown.size", "\u672A\u77E5\u5927\u5C0F"},
+        {"key.bit", "%s \u5BC6\u94A5"},
+        {"key.bit.weak", "%s \u5BC6\u94A5\uFF08\u5F31\uFF09"},
+        {"key.bit.disabled", "%s \u5BC6\u94A5\uFF08\u5DF2\u7981\u7528\uFF09"},
         {"nonexistent.entries.found", "\u6B64 jar \u7684\u6587\u4EF6\u5305\u542B\u4E0D\u5B58\u5728\u7684\u7B7E\u540D\u6761\u76EE\u3002\u6709\u5173\u66F4\u591A\u8BE6\u7EC6\u4FE1\u606F\uFF0C\u8BF7\u53C2\u89C1 -verbose \u8F93\u51FA\u3002"},
         {"external.file.attributes.detected", "\u68C0\u6D4B\u5230 POSIX \u6587\u4EF6\u6743\u9650\u548C/\u6216 symlink \u5C5E\u6027\u3002\u8FD9\u4E9B\u5C5E\u6027\u5728\u8FDB\u884C\u7B7E\u540D\u65F6\u4F1A\u88AB\u5FFD\u7565\uFF0C\u4E0D\u53D7\u8BE5\u7B7E\u540D\u7684\u4FDD\u62A4\u3002"},
 
@@ -295,10 +292,12 @@ public class Resources_zh_CN extends java.util.ListResourceBundle {
                 "%1$s \u6458\u8981\u7B97\u6CD5\u88AB\u89C6\u4E3A\u5B58\u5728\u5B89\u5168\u98CE\u9669\u3002\u6B64\u7B97\u6CD5\u5C06\u5728\u672A\u6765\u7684\u66F4\u65B0\u4E2D\u88AB\u7981\u7528\u3002"},
         {"The.signature.algorithm.1.is.considered.a.security.risk..This.algorithm.will.be.disabled.in.a.future.update.",
                 "%1$s \u7B7E\u540D\u7B97\u6CD5\u88AB\u89C6\u4E3A\u5B58\u5728\u5B89\u5168\u98CE\u9669\u3002\u6B64\u7B97\u6CD5\u5C06\u5728\u672A\u6765\u7684\u66F4\u65B0\u4E2D\u88AB\u7981\u7528\u3002"},
-        {"The.1.signing.key.has.a.keysize.of.2.which.is.considered.a.security.risk..This.key.size.will.be.disabled.in.a.future.update.",
-                "%1$s \u7B7E\u540D\u5BC6\u94A5\u7684\u5BC6\u94A5\u5927\u5C0F %2$d \u88AB\u89C6\u4E3A\u5B58\u5728\u5B89\u5168\u98CE\u9669\u3002\u6B64\u5BC6\u94A5\u5927\u5C0F\u5C06\u5728\u672A\u6765\u7684\u66F4\u65B0\u4E2D\u88AB\u7981\u7528\u3002"},
-        {"The.1.signing.key.has.a.keysize.of.2.which.is.considered.a.security.risk.and.is.disabled.",
-                "%1$s \u7B7E\u540D\u5BC6\u94A5\u7684\u5BC6\u94A5\u5927\u5C0F %2$d \u88AB\u89C6\u4E3A\u5B58\u5728\u5B89\u5168\u98CE\u9669\u800C\u4E14\u88AB\u7981\u7528\u3002"},
+        {"size.bit.alg",
+                "%1$d \u4F4D %2$s"},
+        {"The.full.keyAlgName.signing.key.is.considered.a.security.risk..It.will.be.disabled.in.a.future.update.",
+                "%s \u7B7E\u540D\u5BC6\u94A5\u88AB\u89C6\u4E3A\u5B89\u5168\u98CE\u9669\u3002\u5728\u5C06\u6765\u7684\u66F4\u65B0\u4E2D\u5C06\u7981\u7528\u5B83\u3002"},
+        {"The.full.keyAlgName.signing.key.is.considered.a.security.risk.and.is.disabled.",
+                "%s \u7B7E\u540D\u5BC6\u94A5\u88AB\u89C6\u4E3A\u5B89\u5168\u98CE\u9669\u5E76\u88AB\u7981\u7528\u3002"},
         {"This.jar.contains.entries.whose.certificate.chain.is.invalid.reason.1",
                  "\u6B64 jar \u5305\u542B\u5176\u8BC1\u4E66\u94FE\u65E0\u6548\u7684\u6761\u76EE\u3002\u539F\u56E0: %s"},
         {"This.jar.contains.entries.whose.tsa.certificate.chain.is.invalid.reason.1",


### PR DESCRIPTION
Please review this PR which contains a backport of commit [7c9a7840](https://github.com/openjdk/jdk/commit/7c9a7840ea75a9a7df3f240d063e9833f535e6ec) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

This updates some localized resources in `jarsigner` and `keytool` to sync with the English ones. The fix-request comment has been applied on the JBS issue. The commit being backported was authored by Justin Lu on 6 Mar 2025 and was reviewed by Weijun Wang.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8351223](https://bugs.openjdk.org/browse/JDK-8351223) needs maintainer approval

### Issue
 * [JDK-8351223](https://bugs.openjdk.org/browse/JDK-8351223): Update localized resources in keytool and jarsigner (**Bug** - P4 - Approved)


### Reviewers
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk24u.git pull/116/head:pull/116` \
`$ git checkout pull/116`

Update a local copy of the PR: \
`$ git checkout pull/116` \
`$ git pull https://git.openjdk.org/jdk24u.git pull/116/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 116`

View PR using the GUI difftool: \
`$ git pr show -t 116`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk24u/pull/116.diff">https://git.openjdk.org/jdk24u/pull/116.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk24u/pull/116#issuecomment-2705164962)
</details>
