### PR TITLE
8350202: Tune for Power10 CPUs on Linux ppc64le

### DIFF
--- a/make/autoconf/flags-cflags.m4
+++ b/make/autoconf/flags-cflags.m4
@@ -743,7 +743,7 @@ AC_DEFUN([FLAGS_SETUP_CFLAGS_CPU_DEP],
       elif test "x$FLAGS_CPU" = xppc64le; then
         # Little endian machine uses ELFv2 ABI.
         # Use Power8, this is the first CPU to support PPC64 LE with ELFv2 ABI.
-        $1_CFLAGS_CPU_JVM="${$1_CFLAGS_CPU_JVM} -DABI_ELFv2 -mcpu=power8 -mtune=power8"
+        $1_CFLAGS_CPU_JVM="${$1_CFLAGS_CPU_JVM} -DABI_ELFv2 -mcpu=power8 -mtune=power10"
       fi
     elif test "x$FLAGS_CPU" = xs390x; then
       $1_CFLAGS_CPU="-mbackchain -march=z10"
@@ -764,7 +764,7 @@ AC_DEFUN([FLAGS_SETUP_CFLAGS_CPU_DEP],
       if test "x$FLAGS_CPU" = xppc64le; then
         # Little endian machine uses ELFv2 ABI.
         # Use Power8, this is the first CPU to support PPC64 LE with ELFv2 ABI.
-        $1_CFLAGS_CPU_JVM="${$1_CFLAGS_CPU_JVM} -DABI_ELFv2 -mcpu=power8 -mtune=power8"
+        $1_CFLAGS_CPU_JVM="${$1_CFLAGS_CPU_JVM} -DABI_ELFv2 -mcpu=power8 -mtune=power10"
       fi
     fi
     if test "x$OPENJDK_TARGET_OS" = xaix; then


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8350202](https://bugs.openjdk.org/browse/JDK-8350202) needs maintainer approval

### Issue
 * [JDK-8350202](https://bugs.openjdk.org/browse/JDK-8350202): Tune for Power10 CPUs on Linux ppc64le (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk24u.git pull/119/head:pull/119` \
`$ git checkout pull/119`

Update a local copy of the PR: \
`$ git checkout pull/119` \
`$ git pull https://git.openjdk.org/jdk24u.git pull/119/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 119`

View PR using the GUI difftool: \
`$ git pr show -t 119`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk24u/pull/119.diff">https://git.openjdk.org/jdk24u/pull/119.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk24u/pull/119#issuecomment-2706742139)
</details>
