### PR TITLE
8281511: java/net/ipv6tests/UdpTest.java fails with checkTime failed

### DIFF
--- a/test/jdk/java/net/ipv6tests/TcpTest.java
+++ b/test/jdk/java/net/ipv6tests/TcpTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,6 +36,7 @@
 
 import java.net.*;
 import java.io.*;
+import java.util.concurrent.TimeUnit;
 
 public class TcpTest extends Tests {
     static ServerSocket server, server1, server2;
@@ -193,13 +194,14 @@ public class TcpTest extends Tests {
         server = new ServerSocket (0);
         server.setSoTimeout (5000);
         int port = server.getLocalPort();
-        long t1 = System.currentTimeMillis();
+        long t1 = System.nanoTime();
         try {
             server.accept ();
             throw new RuntimeException ("accept should not have returned");
         } catch (SocketTimeoutException e) {}
-        t1 = System.currentTimeMillis() - t1;
-        checkTime (t1, 5000);
+        t1 = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - t1);
+        final long expectedTime = TimeUnit.SECONDS.toMillis(5);
+        checkIfTimeOut(TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - t1), expectedTime);
 
         c1 = new Socket ();
         c1.connect (new InetSocketAddress (ia4addr, port), 1000);

--- a/test/jdk/java/net/ipv6tests/Tests.java
+++ b/test/jdk/java/net/ipv6tests/Tests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -151,19 +151,14 @@ public class Tests {
         }
     }
 
-    /* check the time got is within 50% of the time expected */
-    public static void checkTime (long got, long expected) {
-        checkTime(got, expected, expected);
-    }
 
-    /* check the time got is between start and end, given 50% tolerance */
-    public static void checkTime(long got, long start, long end) {
-        dprintln("checkTime: got = " + got + " start = " + start + " end = " + end);
-        long upper = end + (end / 2);
-        long lower = start - (start / 2);
-        if (got > upper || got < lower) {
-            throw new RuntimeException("checkTime failed: got " + got
-                    + ", expected between " + start + " and " + end);
+    /* check the timeout breached lower bound time rule */
+    public static void checkIfTimeOut(long got, long expected) {
+        dprintln("checkIfTimeOut: got = " + got + " lower bound = " + expected);
+
+        if (got < expected) {
+            throw new RuntimeException("checkIfTimeOut failed: got " + got
+                    + ", expected at least " + expected );
         }
     }
 

--- a/test/jdk/java/net/ipv6tests/UdpTest.java
+++ b/test/jdk/java/net/ipv6tests/UdpTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -41,6 +41,7 @@ import java.net.Inet6Address;
 import java.net.InetAddress;
 import java.net.PortUnreachableException;
 import java.net.SocketTimeoutException;
+import java.util.concurrent.TimeUnit;
 
 public class UdpTest extends Tests {
     static DatagramSocket c3, s1, s2, s3;
@@ -138,26 +139,27 @@ public class UdpTest extends Tests {
         s1 = new DatagramSocket ();
         s2 = new DatagramSocket ();
         s1.setSoTimeout (4000);
-        long t1 = System.currentTimeMillis();
+        long t1 = System.nanoTime();
         try {
             s1.receive (new DatagramPacket (new byte [128], 128));
             throw new Exception ("expected receive timeout ");
         } catch (SocketTimeoutException e) {
         }
-        checkTime (System.currentTimeMillis() - t1, 4000);
+        final long expectedTime = TimeUnit.SECONDS.toMillis(4);
+        checkIfTimeOut(TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - t1), expectedTime);
 
         /* check data can be exchanged now */
 
         simpleDataExchange (s1, ia6addr, s2, ia4addr);
 
         /* double check timeout still works */
-        t1 = System.currentTimeMillis();
+        t1 = System.nanoTime();
         try {
             s1.receive (new DatagramPacket (new byte [128], 128));
             throw new Exception ("expected receive timeout ");
         } catch (SocketTimeoutException e) {
         }
-        checkTime (System.currentTimeMillis() - t1, 4000);
+        checkIfTimeOut(TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - t1), expectedTime);
 
         /* check receive works after a delay < timeout */
 
@@ -174,9 +176,10 @@ public class UdpTest extends Tests {
                 } catch (Exception e) {}
             }
         });
-        t1 = System.currentTimeMillis();
+        t1 = System.nanoTime();
         s1.receive (new DatagramPacket (new byte [128], 128));
-        checkTime (System.currentTimeMillis() - t1, 2000, 10000);
+        final long startTime = TimeUnit.SECONDS.toMillis(2);
+        checkIfTimeOut(TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - t1), startTime);
         s1.close ();
         s2.close ();
         System.out.println ("Test2: OK");


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [ea9e3cfe](https://github.com/openjdk/jdk/commit/ea9e3cfe03b5284ef0edc6f0eb92fcb6ffd62725) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Serhiy Sachkov on 5 Mar 2025 and was reviewed by Daniel Fuchs.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8281511](https://bugs.openjdk.org/browse/JDK-8281511) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8281511](https://bugs.openjdk.org/browse/JDK-8281511): java/net/ipv6tests/UdpTest.java fails with checkTime failed (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk24u.git pull/121/head:pull/121` \
`$ git checkout pull/121`

Update a local copy of the PR: \
`$ git checkout pull/121` \
`$ git pull https://git.openjdk.org/jdk24u.git pull/121/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 121`

View PR using the GUI difftool: \
`$ git pr show -t 121`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk24u/pull/121.diff">https://git.openjdk.org/jdk24u/pull/121.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk24u/pull/121#issuecomment-2708308105)
</details>
