### PR TITLE
8350103: Test containers/systemd/SystemdMemoryAwarenessTest.java fails on Linux ppc64le SLES15 SP6

### DIFF
--- a/test/hotspot/jtreg/containers/systemd/SystemdMemoryAwarenessTest.java
+++ b/test/hotspot/jtreg/containers/systemd/SystemdMemoryAwarenessTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, Red Hat, Inc.
+ * Copyright (c) 2024, 2025, Red Hat, Inc.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -68,14 +68,14 @@ public class SystemdMemoryAwarenessTest {
 
         OutputAnalyzer out = SystemdTestUtils.buildAndRunSystemdJava(opts);
         out.shouldHaveExitValue(0)
-           .shouldContain("Hello Systemd")
-           .shouldContain(String.format("Memory Limit is: %d", (expectedMemLimit * MB)));
+           .shouldContain("Hello Systemd");
         try {
+            out.shouldContain(String.format("Memory Limit is: %d", (expectedMemLimit * MB)));
             out.shouldContain("OSContainer::active_processor_count: " + coreLimit);
         } catch (RuntimeException e) {
-            // CPU delegation needs to be enabled when run as user on cg v2
+            // CPU/memory delegation needs to be enabled when run as user on cg v2
             if (SystemdTestUtils.RUN_AS_USER) {
-                String hint = "When run as user on cg v2 cpu delegation needs to be configured!";
+                String hint = "When run as user on cg v2 cpu/memory delegation needs to be configured!";
                 throw new SkippedException(hint);
             }
             throw e;


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8350103](https://bugs.openjdk.org/browse/JDK-8350103) needs maintainer approval

### Issue
 * [JDK-8350103](https://bugs.openjdk.org/browse/JDK-8350103): Test containers/systemd/SystemdMemoryAwarenessTest.java fails on Linux ppc64le SLES15 SP6 (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk24u.git pull/127/head:pull/127` \
`$ git checkout pull/127`

Update a local copy of the PR: \
`$ git checkout pull/127` \
`$ git pull https://git.openjdk.org/jdk24u.git pull/127/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 127`

View PR using the GUI difftool: \
`$ git pr show -t 127`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk24u/pull/127.diff">https://git.openjdk.org/jdk24u/pull/127.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk24u/pull/127#issuecomment-2713479176)
</details>
