### PR TITLE
8286204: [Accessibility,macOS,VoiceOver] VoiceOver reads the spinner value 10 as 1 when user iterates to 10 for the first time on macOS

### DIFF
--- a/src/java.desktop/macosx/classes/sun/lwawt/macosx/CAccessible.java
+++ b/src/java.desktop/macosx/classes/sun/lwawt/macosx/CAccessible.java
@@ -32,6 +32,7 @@ import java.util.Objects;
 
 import javax.accessibility.Accessible;
 import javax.accessibility.AccessibleContext;
+import javax.swing.JSpinner;
 import javax.swing.JTabbedPane;
 
 import static javax.accessibility.AccessibleContext.ACCESSIBLE_ACTIVE_DESCENDANT_PROPERTY;
@@ -121,7 +122,11 @@ class CAccessible extends CFRetainedResource implements Accessible {
                 if (name.equals(ACCESSIBLE_CARET_PROPERTY)) {
                     selectedTextChanged(ptr);
                 } else if (name.equals(ACCESSIBLE_TEXT_PROPERTY)) {
-                    valueChanged(ptr);
+                    AccessibleContext thisAC = accessible.getAccessibleContext();
+                    Accessible parentAccessible = thisAC.getAccessibleParent();
+                    if (!(parentAccessible instanceof JSpinner.NumberEditor)) {
+                        valueChanged(ptr);
+                    }
                 } else if (name.equals(ACCESSIBLE_SELECTION_PROPERTY)) {
                     selectionChanged(ptr);
                 } else if (name.equals(ACCESSIBLE_TABLE_MODEL_CHANGED)) {

--- a/test/jdk/javax/accessibility/TestJSpinnerAccessibility.java
+++ b/test/jdk/javax/accessibility/TestJSpinnerAccessibility.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.BorderLayout;
+
+import javax.swing.JFrame;
+import javax.swing.JSpinner;
+import javax.swing.SpinnerModel;
+import javax.swing.SpinnerNumberModel;
+
+/*
+ * @test
+ * @bug 8286204
+ * @summary Verifies that VoiceOver announces the JSpinner's value correctly
+ * @requires os.family == "mac"
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual TestJSpinnerAccessibility
+ */
+
+public class TestJSpinnerAccessibility {
+    public static void main(String[] args) throws Exception {
+        String INSTRUCTIONS = """
+                Test UI contains a JSpinner with minimum value 0, maximum value 20
+                and current value 5. On press of up / down arrow, value will be
+                incremented / decremented by 1.
+
+                Follow these steps to test the behaviour:
+
+                1. Start the VoiceOver (Press Command + F5) application
+                2. Move focus on test window if it is not focused
+                3. Press Up / Down arrow to increase / decrease Spinner value
+                4. VO should announce correct values in terms of percentage
+                   (e.g. For JSpinner's value 10, VO should announce 50%)
+                5. Press Pass if you are able to hear correct announcements
+                   else Fail""";
+
+        PassFailJFrame.builder()
+                .title("TestJSpinnerAccessibility Instruction")
+                .instructions(INSTRUCTIONS)
+                .columns(40)
+                .testUI(TestJSpinnerAccessibility::createUI)
+                .build()
+                .awaitAndCheck();
+    }
+
+    private static JFrame createUI() {
+        JFrame frame = new JFrame("A Frame with JSpinner");
+        SpinnerModel spinnerModel = new SpinnerNumberModel(5, 0, 20, 1);
+        JSpinner spinner = new JSpinner(spinnerModel);
+        frame.getContentPane().add(spinner, BorderLayout.CENTER);
+        frame.setSize(200, 100);
+        return frame;
+    }
+}


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [cd9f1d3d](https://github.com/openjdk/jdk/commit/cd9f1d3d921531511a7552807d099d5d3cce01a6) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Abhishek Kumar on 11 Mar 2025 and was reviewed by Harshitha Onkar, Alexander Zuev and Artem Semenov.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8286204](https://bugs.openjdk.org/browse/JDK-8286204) needs maintainer approval

### Issue
 * [JDK-8286204](https://bugs.openjdk.org/browse/JDK-8286204): [Accessibility,macOS,VoiceOver] VoiceOver reads the spinner value 10 as 1 when user iterates to 10 for the first time on macOS (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk24u.git pull/128/head:pull/128` \
`$ git checkout pull/128`

Update a local copy of the PR: \
`$ git checkout pull/128` \
`$ git pull https://git.openjdk.org/jdk24u.git pull/128/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 128`

View PR using the GUI difftool: \
`$ git pr show -t 128`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk24u/pull/128.diff">https://git.openjdk.org/jdk24u/pull/128.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk24u/pull/128#issuecomment-2714781072)
</details>
