### PR TITLE
8346285: Update jarsigner compatibility test for change in default digest algorithm

### DIFF
--- a/test/jdk/sun/security/tools/jarsigner/compatibility/Compatibility.java
+++ b/test/jdk/sun/security/tools/jarsigner/compatibility/Compatibility.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -67,6 +67,7 @@ import java.util.jar.Manifest;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
+import jdk.security.jarsigner.JarSigner;
 import jdk.test.lib.process.OutputAnalyzer;
 import jdk.test.lib.process.ProcessTools;
 import jdk.test.lib.util.JarUtils;
@@ -1437,7 +1438,9 @@ public class Compatibility {
         String expectedDigestAlg() {
             return digestAlgorithm != null
                     ? digestAlgorithm
-                    : jdkInfo.majorVersion >= 20 ? "SHA-384" : "SHA-256";
+                    : jdkInfo.majorVersion >= 20
+                        ? JarSigner.Builder.getDefaultDigestAlgorithm()
+                        : "SHA-256";
         }
 
         private SignItem tsaDigestAlgorithm(String tsaDigestAlgorithm) {
@@ -1446,7 +1449,11 @@ public class Compatibility {
         }
 
         String expectedTsaDigestAlg() {
-            return tsaDigestAlgorithm != null ? tsaDigestAlgorithm : "SHA-256";
+            return tsaDigestAlgorithm != null
+                    ? tsaDigestAlgorithm
+                    : jdkInfo.majorVersion >= 20
+                        ? JarSigner.Builder.getDefaultDigestAlgorithm()
+                        : "SHA-256";
         }
 
         private SignItem tsaIndex(int tsaIndex) {


### PR DESCRIPTION
Clean backport

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8346285](https://bugs.openjdk.org/browse/JDK-8346285) needs maintainer approval

### Issue
 * [JDK-8346285](https://bugs.openjdk.org/browse/JDK-8346285): Update jarsigner compatibility test for change in default digest algorithm (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk24u.git pull/135/head:pull/135` \
`$ git checkout pull/135`

Update a local copy of the PR: \
`$ git checkout pull/135` \
`$ git pull https://git.openjdk.org/jdk24u.git pull/135/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 135`

View PR using the GUI difftool: \
`$ git pr show -t 135`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk24u/pull/135.diff">https://git.openjdk.org/jdk24u/pull/135.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk24u/pull/135#issuecomment-2721628709)
</details>
