### PR TITLE
8351086: (fc) Make java/nio/channels/FileChannel/BlockDeviceSize.java test manual

### DIFF
--- a/test/jdk/java/nio/channels/FileChannel/BlockDeviceSize.java
+++ b/test/jdk/java/nio/channels/FileChannel/BlockDeviceSize.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,10 @@
  * @bug 8054029 8313368
  * @requires (os.family == "linux")
  * @summary FileChannel.size() should be equal to RandomAccessFile.size() and > 0 for block devs on Linux
+ * @comment The test must be launched with sudo or the block devices listed in
+ * the BLK_FNAMES array must be readable by the user running the test.
  * @library /test/lib
+ * @run main/manual BlockDeviceSize
  */
 
 import java.io.RandomAccessFile;


### PR DESCRIPTION
Clean backport of https://github.com/openjdk/jdk/commit/08929134b3533362133139c4e964b1b28de6ebfb - Changing test/jdk/java/nio/channels/FileChannel/BlockDeviceSize.java to a manual test.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8351086](https://bugs.openjdk.org/browse/JDK-8351086) needs maintainer approval

### Issue
 * [JDK-8351086](https://bugs.openjdk.org/browse/JDK-8351086): (fc) Make java/nio/channels/FileChannel/BlockDeviceSize.java test manual (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk24u.git pull/136/head:pull/136` \
`$ git checkout pull/136`

Update a local copy of the PR: \
`$ git checkout pull/136` \
`$ git pull https://git.openjdk.org/jdk24u.git pull/136/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 136`

View PR using the GUI difftool: \
`$ git pr show -t 136`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk24u/pull/136.diff">https://git.openjdk.org/jdk24u/pull/136.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk24u/pull/136#issuecomment-2723701110)
</details>
