### PR TITLE
8351639: Improve debuggability of test/langtools/jdk/jshell/JdiHangingListenExecutionControlTest.java test

### DIFF
--- a/test/langtools/jdk/jshell/JdiHangingListenExecutionControlTest.java
+++ b/test/langtools/jdk/jshell/JdiHangingListenExecutionControlTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -46,7 +46,11 @@ public class JdiHangingListenExecutionControlTest {
             System.err.printf("Unexpected return value: %s\n",
                     HangingRemoteAgent.state(false, null).eval("33;"));
         } catch (IllegalStateException ex) {
-            assertTrue(ex.getMessage().startsWith(EXPECTED_ERROR), ex.getMessage());
+            if (!ex.getMessage().startsWith(EXPECTED_ERROR)) {
+                // unexpected message in the exception, rethrow the original exception
+                throw ex;
+            }
+            // received expected exception
             return;
         }
         fail("Expected IllegalStateException");


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [4412c079](https://github.com/openjdk/jdk/commit/4412c079fccefbb235b22651206089f5bac47d18) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Jaikiran Pai on 12 Mar 2025 and was reviewed by Jan Lahoda.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8351639](https://bugs.openjdk.org/browse/JDK-8351639) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8351639](https://bugs.openjdk.org/browse/JDK-8351639): Improve debuggability of test/langtools/jdk/jshell/JdiHangingListenExecutionControlTest.java test (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk24u.git pull/137/head:pull/137` \
`$ git checkout pull/137`

Update a local copy of the PR: \
`$ git checkout pull/137` \
`$ git pull https://git.openjdk.org/jdk24u.git pull/137/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 137`

View PR using the GUI difftool: \
`$ git pr show -t 137`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk24u/pull/137.diff">https://git.openjdk.org/jdk24u/pull/137.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk24u/pull/137#issuecomment-2723793601)
</details>
