### PR TITLE
8350683: Non-C2 / minimal JVM crashes in the build on ppc64 platforms

### DIFF
--- a/src/hotspot/cpu/ppc/compiledIC_ppc.cpp
+++ b/src/hotspot/cpu/ppc/compiledIC_ppc.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2012, 2015 SAP SE. All rights reserved.
+ * Copyright (c) 2012, 2025 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,9 +30,6 @@
 #include "memory/resourceArea.hpp"
 #include "runtime/mutexLocker.hpp"
 #include "runtime/safepoint.hpp"
-#ifdef COMPILER2
-#include "opto/matcher.hpp"
-#endif
 
 // ----------------------------------------------------------------------------
 
@@ -79,7 +76,6 @@
 const int IC_pos_in_java_to_interp_stub = 8;
 #define __ masm->
 address CompiledDirectCall::emit_to_interp_stub(MacroAssembler *masm, address mark/* = nullptr*/) {
-#ifdef COMPILER2
   if (mark == nullptr) {
     // Get the mark within main instrs section which is set to the address of the call.
     mark = __ inst_mark();
@@ -109,7 +105,7 @@ address CompiledDirectCall::emit_to_interp_stub(MacroAssembler *masm, address ma
   // - call
   __ calculate_address_from_global_toc(reg_scratch, __ method_toc());
   AddressLiteral ic = __ allocate_metadata_address((Metadata *)nullptr);
-  bool success = __ load_const_from_method_toc(as_Register(Matcher::inline_cache_reg_encode()),
+  bool success = __ load_const_from_method_toc(R19_inline_cache_reg,
                                                ic, reg_scratch, /*fixed_size*/ true);
   if (!success) {
     return nullptr; // CodeCache is full
@@ -135,13 +131,9 @@ address CompiledDirectCall::emit_to_interp_stub(MacroAssembler *masm, address ma
   assert(!is_NativeCallTrampolineStub_at(__ addr_at(stub_start_offset)),
          "must not confuse java_to_interp with trampoline stubs");
 
- // End the stub.
+  // End the stub.
   __ end_a_stub();
   return stub;
-#else
-  ShouldNotReachHere();
-  return nullptr;
-#endif
 }
 #undef __
 


### PR DESCRIPTION
Backport 8350683, adjust COPYRIGHT header

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8350683](https://bugs.openjdk.org/browse/JDK-8350683) needs maintainer approval

### Issue
 * [JDK-8350683](https://bugs.openjdk.org/browse/JDK-8350683): Non-C2 / minimal JVM crashes in the build on ppc64 platforms (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk24u.git pull/142/head:pull/142` \
`$ git checkout pull/142`

Update a local copy of the PR: \
`$ git checkout pull/142` \
`$ git pull https://git.openjdk.org/jdk24u.git pull/142/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 142`

View PR using the GUI difftool: \
`$ git pr show -t 142`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk24u/pull/142.diff">https://git.openjdk.org/jdk24u/pull/142.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk24u/pull/142#issuecomment-2733928316)
</details>
