### PR TITLE
8351933: Inaccurate masking of TC subfield decrement in ForkJoinPool

### DIFF
--- a/src/java.base/share/classes/java/util/concurrent/ForkJoinPool.java
+++ b/src/java.base/share/classes/java/util/concurrent/ForkJoinPool.java
@@ -2077,7 +2077,8 @@ public class ForkJoinPool extends AbstractExecutorService {
         else if (deadline - System.currentTimeMillis() >= TIMEOUT_SLOP)
             stat = 0;                       // spurious wakeup
         else if (!compareAndSetCtl(
-                     c, nc = (w.stackPred & LMASK) | (UMASK & (c - TC_UNIT))))
+                     c, nc = ((w.stackPred & LMASK) | (RC_MASK & c) |
+                               (TC_MASK & (c - TC_UNIT)))))
             stat = -1;                      // lost race to signaller
         else {
             stat = 1;


### PR DESCRIPTION
This is a clean backport of a tiny ForkJoinPool change that corrects the TC subfield masking.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8351933](https://bugs.openjdk.org/browse/JDK-8351933) needs maintainer approval

### Issue
 * [JDK-8351933](https://bugs.openjdk.org/browse/JDK-8351933): Inaccurate masking of TC subfield decrement in ForkJoinPool (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk24u.git pull/148/head:pull/148` \
`$ git checkout pull/148`

Update a local copy of the PR: \
`$ git checkout pull/148` \
`$ git pull https://git.openjdk.org/jdk24u.git pull/148/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 148`

View PR using the GUI difftool: \
`$ git pr show -t 148`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk24u/pull/148.diff">https://git.openjdk.org/jdk24u/pull/148.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk24u/pull/148#issuecomment-2736410928)
</details>
