### PR TITLE
8336042: Caller/callee param size mismatch in deoptimization causes crash

### DIFF
--- a/src/hotspot/cpu/aarch64/abstractInterpreter_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/abstractInterpreter_aarch64.cpp
@@ -150,7 +150,8 @@ void AbstractInterpreter::layout_activation(Method* method,
 
 #ifdef ASSERT
   if (caller->is_interpreted_frame()) {
-    assert(locals < caller->fp() + frame::interpreter_frame_initial_sp_offset, "bad placement");
+    assert(locals <= caller->interpreter_frame_expression_stack(), "bad placement");
+    assert(locals >= interpreter_frame->sender_sp() + max_locals - 1, "bad placement");
   }
 #endif
 

--- a/src/hotspot/cpu/arm/abstractInterpreter_arm.cpp
+++ b/src/hotspot/cpu/arm/abstractInterpreter_arm.cpp
@@ -132,6 +132,15 @@ void AbstractInterpreter::layout_activation(Method* method,
 
   intptr_t* locals = interpreter_frame->sender_sp() + max_locals - 1;
 
+#ifdef ASSERT
+  if (caller->is_interpreted_frame()) {
+    // Test exact placement on top of caller args
+    intptr_t* l2 = caller->interpreter_frame_last_sp() + caller_actual_parameters - 1;
+    assert(l2 <= caller->interpreter_frame_expression_stack(), "bad placement");
+    assert(l2 >= locals, "bad placement");
+  }
+#endif
+
   interpreter_frame->interpreter_frame_set_locals(locals);
   BasicObjectLock* montop = interpreter_frame->interpreter_frame_monitor_begin();
   BasicObjectLock* monbot = montop - moncount;

--- a/src/hotspot/cpu/ppc/abstractInterpreter_ppc.cpp
+++ b/src/hotspot/cpu/ppc/abstractInterpreter_ppc.cpp
@@ -129,6 +129,15 @@ void AbstractInterpreter::layout_activation(Method* method,
     caller->interpreter_frame_esp() + caller_actual_parameters :
     caller->sp() + method->max_locals() - 1 + (frame::java_abi_size / Interpreter::stackElementSize);
 
+#ifdef ASSERT
+  if (caller->is_interpreted_frame()) {
+    assert(locals_base <= caller->interpreter_frame_expression_stack(), "bad placement");
+    const int caller_abi_bytesize = (is_bottom_frame ? frame::top_ijava_frame_abi_size : frame::parent_ijava_frame_abi_size);
+    intptr_t* l2 = caller->sp() + method->max_locals() - 1 + (caller_abi_bytesize / Interpreter::stackElementSize);
+    assert(locals_base >= l2, "bad placement");
+  }
+#endif
+
   intptr_t* monitor_base = caller->sp() - frame::ijava_state_size / Interpreter::stackElementSize;
   intptr_t* monitor      = monitor_base - (moncount * frame::interpreter_frame_monitor_size());
   intptr_t* esp_base     = monitor - 1;

--- a/src/hotspot/cpu/riscv/abstractInterpreter_riscv.cpp
+++ b/src/hotspot/cpu/riscv/abstractInterpreter_riscv.cpp
@@ -142,7 +142,8 @@ void AbstractInterpreter::layout_activation(Method* method,
 
 #ifdef ASSERT
   if (caller->is_interpreted_frame()) {
-    assert(locals < caller->fp() + frame::interpreter_frame_initial_sp_offset, "bad placement");
+    assert(locals <= caller->interpreter_frame_expression_stack(), "bad placement");
+    assert(locals >= interpreter_frame->sender_sp() + max_locals - 1, "bad placement");
   }
 #endif
 

--- a/src/hotspot/cpu/s390/abstractInterpreter_s390.cpp
+++ b/src/hotspot/cpu/s390/abstractInterpreter_s390.cpp
@@ -183,6 +183,13 @@ void AbstractInterpreter::layout_activation(Method* method,
   intptr_t* sender_sp;
   if (caller->is_interpreted_frame()) {
     sender_sp = caller->interpreter_frame_top_frame_sp();
+#ifdef ASSERT
+    assert(locals_base <= caller->interpreter_frame_expression_stack(), "bad placement");
+    // Test caller-aligned placement vs callee-aligned
+    intptr_t* l2 = (caller->sp() + method->max_locals() - 1 +
+      frame::z_parent_ijava_frame_abi_size / Interpreter::stackElementSize);
+    assert(locals_base >= l2, "bad placement");
+#endif
   } else if (caller->is_compiled_frame()) {
     sender_sp = caller->fp() - caller->cb()->frame_size();
     // The bottom frame's sender_sp is its caller's unextended_sp.

--- a/src/hotspot/cpu/x86/abstractInterpreter_x86.cpp
+++ b/src/hotspot/cpu/x86/abstractInterpreter_x86.cpp
@@ -88,7 +88,10 @@ void AbstractInterpreter::layout_activation(Method* method,
 
 #ifdef ASSERT
   if (caller->is_interpreted_frame()) {
-    assert(locals < caller->fp() + frame::interpreter_frame_initial_sp_offset, "bad placement");
+    // Test exact placement on top of caller args
+    intptr_t* l2 = caller->interpreter_frame_last_sp() + caller_actual_parameters - 1;
+    assert(l2 <= caller->interpreter_frame_expression_stack(), "bad placement");
+    assert(l2 >= locals, "bad placement");
   }
 #endif
 

--- a/src/hotspot/share/interpreter/bytecode.hpp
+++ b/src/hotspot/share/interpreter/bytecode.hpp
@@ -226,6 +226,8 @@ class Bytecode_invoke: public Bytecode_member_ref {
 
   bool has_appendix();
 
+  bool has_member_arg() const;
+
   int size_of_parameters() const;
 
  private:

--- a/src/hotspot/share/interpreter/bytecode.inline.hpp
+++ b/src/hotspot/share/interpreter/bytecode.inline.hpp
@@ -28,6 +28,7 @@
 #include "interpreter/bytecode.hpp"
 
 #include "oops/cpCache.inline.hpp"
+#include "prims/methodHandles.hpp"
 
 inline bool Bytecode_invoke::has_appendix() {
   if (invoke_code() == Bytecodes::_invokedynamic) {
@@ -35,6 +36,15 @@ inline bool Bytecode_invoke::has_appendix() {
   } else {
     return resolved_method_entry()->has_appendix();
   }
+}
+
+inline bool Bytecode_invoke::has_member_arg() const {
+  // NOTE: We could resolve the call and use the resolved adapter method here, but this function
+  // is used by deoptimization, where resolving could lead to problems, so we avoid that here
+  // by doing things symbolically.
+  //
+  // invokedynamic instructions don't have a class but obviously don't have a MemberName appendix.
+  return !is_invokedynamic() && MethodHandles::has_member_arg(klass(), name());
 }
 
 #endif // SHARE_INTERPRETER_BYTECODE_INLINE_HPP

--- a/src/hotspot/share/runtime/deoptimization.cpp
+++ b/src/hotspot/share/runtime/deoptimization.cpp
@@ -37,6 +37,7 @@
 #include "gc/shared/collectedHeap.hpp"
 #include "gc/shared/memAllocator.hpp"
 #include "interpreter/bytecode.hpp"
+#include "interpreter/bytecode.inline.hpp"
 #include "interpreter/bytecodeStream.hpp"
 #include "interpreter/interpreter.hpp"
 #include "interpreter/oopMapCache.hpp"
@@ -642,11 +643,12 @@ Deoptimization::UnrollBlock* Deoptimization::fetch_unroll_info_helper(JavaThread
   bool caller_was_method_handle = false;
   if (deopt_sender.is_interpreted_frame()) {
     methodHandle method(current, deopt_sender.interpreter_frame_method());
-    Bytecode_invoke cur = Bytecode_invoke_check(method, deopt_sender.interpreter_frame_bci());
-    if (cur.is_invokedynamic() || cur.is_invokehandle()) {
-      // Method handle invokes may involve fairly arbitrary chains of
-      // calls so it's impossible to know how much actual space the
-      // caller has for locals.
+    Bytecode_invoke cur(method, deopt_sender.interpreter_frame_bci());
+    if (cur.has_member_arg()) {
+      // This should cover all real-world cases.  One exception is a pathological chain of
+      // MH.linkToXXX() linker calls, which only trusted code could do anyway.  To handle that case, we
+      // would need to get the size from the resolved method entry.  Another exception would
+      // be an invokedynamic with an adapter that is really a MethodHandle linker.
       caller_was_method_handle = true;
     }
   }
@@ -749,9 +751,14 @@ Deoptimization::UnrollBlock* Deoptimization::fetch_unroll_info_helper(JavaThread
   }
 #endif
 
+  int caller_actual_parameters = -1; // value not used except for interpreted frames, see below
+  if (deopt_sender.is_interpreted_frame()) {
+    caller_actual_parameters = callee_parameters + (caller_was_method_handle ? 1 : 0);
+  }
+
   UnrollBlock* info = new UnrollBlock(array->frame_size() * BytesPerWord,
                                       caller_adjustment * BytesPerWord,
-                                      caller_was_method_handle ? 0 : callee_parameters,
+                                      caller_actual_parameters,
                                       number_of_frames,
                                       frame_sizes,
                                       frame_pcs,
@@ -940,7 +947,7 @@ JRT_LEAF(BasicType, Deoptimization::unpack_frames(JavaThread* thread, int exec_m
       if (Bytecodes::is_invoke(cur_code)) {
         Bytecode_invoke invoke(mh, iframe->interpreter_frame_bci());
         cur_invoke_parameter_size = invoke.size_of_parameters();
-        if (i != 0 && !invoke.is_invokedynamic() && MethodHandles::has_member_arg(invoke.klass(), invoke.name())) {
+        if (i != 0 && invoke.has_member_arg()) {
           callee_size_of_parameters++;
         }
       }

--- a/src/hotspot/share/runtime/vframeArray.cpp
+++ b/src/hotspot/share/runtime/vframeArray.cpp
@@ -26,6 +26,7 @@
 #include "classfile/vmSymbols.hpp"
 #include "code/vmreg.inline.hpp"
 #include "interpreter/bytecode.hpp"
+#include "interpreter/bytecode.inline.hpp"
 #include "interpreter/interpreter.hpp"
 #include "memory/allocation.inline.hpp"
 #include "memory/resourceArea.hpp"
@@ -614,10 +615,7 @@ void vframeArray::unpack_to_stack(frame &unpack_frame, int exec_mode, int caller
       methodHandle caller(current, elem->method());
       methodHandle callee(current, element(index - 1)->method());
       Bytecode_invoke inv(caller, elem->bci());
-      // invokedynamic instructions don't have a class but obviously don't have a MemberName appendix.
-      // NOTE:  Use machinery here that avoids resolving of any kind.
-      const bool has_member_arg =
-          !inv.is_invokedynamic() && MethodHandles::has_member_arg(inv.klass(), inv.name());
+      const bool has_member_arg = inv.has_member_arg();
       callee_parameters = callee->size_of_parameters() + (has_member_arg ? 1 : 0);
       callee_locals     = callee->max_locals();
     }

--- a/test/hotspot/jtreg/compiler/jsr292/MHDeoptTest.java
+++ b/test/hotspot/jtreg/compiler/jsr292/MHDeoptTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package compiler.jsr292;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodHandles.Lookup;
+import java.lang.invoke.MethodType;
+import java.lang.reflect.Method;
+
+/*
+ * @test
+ * @bug 8336042
+ * @library /test/lib /
+ *
+ * @run main/bootclasspath/othervm -Xbatch -XX:-TieredCompilation compiler.jsr292.MHDeoptTest
+ *
+ */
+public class MHDeoptTest {
+
+    static int xx = 0;
+
+    public static void main(String[] args) throws Throwable {
+        MethodHandle mh1 = MethodHandles.lookup().findStatic(MHDeoptTest.class, "body1", MethodType.methodType(int.class));
+        MethodHandle mh2 = MethodHandles.lookup().findStatic(MHDeoptTest.class, "body2", MethodType.methodType(int.class));
+        MethodHandle[] arr = new MethodHandle[] {mh2, mh1};
+
+        for (MethodHandle mh : arr) {
+            for (int i = 1; i < 50_000; i++) {
+                xx = i;
+                mainLink(mh);
+            }
+        }
+
+    }
+
+    static int mainLink(MethodHandle mh) throws Throwable {
+        return (int)mh.invokeExact();
+    }
+
+    static int cnt = 1000;
+
+    static int body1() {
+        int limit = 0x7fff;
+        // uncommon trap
+        if (xx == limit) {
+            // OSR
+            for (int i = 0; i < 50_000; i++) {
+            }
+            ++cnt;
+            ++xx;
+        }
+        if (xx == limit + 1) {
+            return cnt + 1;
+        }
+        return cnt;
+    }
+
+    static int body2() {
+        int limit = 0x7fff;
+        int dummy = 0;
+        // uncommon trap
+        if (xx == limit) {
+            // OSR
+            for (int i = 0; i < 50_000; i++) {
+            }
+            ++cnt;
+            ++xx;
+        }
+        if (xx == limit + 1) {
+            return cnt + 1;
+        }
+        return cnt;
+    }
+
+}


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [20ea218c](https://github.com/openjdk/jdk/commit/20ea218ce52f79704445acfe2d4a3dc9d04e86d2) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Dean Long on 4 Mar 2025 and was reviewed by Patricio Chilano Mateo, Richard Reingruber, Vladimir Ivanov and Tom Rodriguez.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8336042](https://bugs.openjdk.org/browse/JDK-8336042) needs maintainer approval

### Issue
 * [JDK-8336042](https://bugs.openjdk.org/browse/JDK-8336042): Caller/callee param size mismatch in deoptimization causes crash (**Bug** - P3 - Approved)


### Reviewers
 * [Dean Long](https://openjdk.org/census#dlong) (@dean-long - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk24u.git pull/156/head:pull/156` \
`$ git checkout pull/156`

Update a local copy of the PR: \
`$ git checkout pull/156` \
`$ git pull https://git.openjdk.org/jdk24u.git pull/156/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 156`

View PR using the GUI difftool: \
`$ git pr show -t 156`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk24u/pull/156.diff">https://git.openjdk.org/jdk24u/pull/156.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk24u/pull/156#issuecomment-2749108679)
</details>
