### PR TITLE
8351601: [JMH] test UnixSocketChannelReadWrite failed for 2 threads config

### DIFF
--- a/test/micro/org/openjdk/bench/java/net/UnixSocketChannelReadWrite.java
+++ b/test/micro/org/openjdk/bench/java/net/UnixSocketChannelReadWrite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,7 +31,6 @@ import java.nio.channels.ServerSocketChannel;
 import java.nio.channels.SocketChannel;
 import java.nio.file.*;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicInteger;
 
 import org.openjdk.jmh.annotations.*;
 
@@ -52,22 +51,10 @@ public class UnixSocketChannelReadWrite {
     private ReadThread rt;
     private ByteBuffer bb = ByteBuffer.allocate(1);
 
-    private static volatile String tempDir;
-    private static final AtomicInteger count = new AtomicInteger(0);
     private volatile Path socket;
 
-    static {
-        try {
-            Path p = Files.createTempDirectory("readWriteTest");
-            tempDir = p.toString();
-        } catch (IOException e) {
-            tempDir = null;
-        }
-    }
-
     private ServerSocketChannel getServerSocketChannel() throws IOException {
-        int next = count.incrementAndGet();
-        socket = Paths.get(tempDir, Integer.toString(next));
+        socket = Files.createTempDirectory(UnixSocketChannelReadWrite.class.getSimpleName()).resolve("sock");
         UnixDomainSocketAddress addr = UnixDomainSocketAddress.of(socket);
         ServerSocketChannel c = ServerSocketChannel.open(StandardProtocolFamily.UNIX);
         c.bind(addr);
@@ -93,7 +80,7 @@ public class UnixSocketChannelReadWrite {
         s2.close();
         ssc.close();
         Files.delete(socket);
-        Files.delete(Path.of(tempDir));
+        Files.delete(socket.getParent());
         rt.join();
     }
 


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [03105fc9](https://github.com/openjdk/jdk/commit/03105fc92505e9e367354e763b99cbe02bf473d6) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Volkan Yazici on 25 Mar 2025 and was reviewed by Michael McMahon.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] [JDK-8351601](https://bugs.openjdk.org/browse/JDK-8351601) needs maintainer approval

### Issue
 * [JDK-8351601](https://bugs.openjdk.org/browse/JDK-8351601): [JMH] test UnixSocketChannelReadWrite failed for 2 threads config (**Enhancement** - P4 - Requested)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk24u.git pull/166/head:pull/166` \
`$ git checkout pull/166`

Update a local copy of the PR: \
`$ git checkout pull/166` \
`$ git pull https://git.openjdk.org/jdk24u.git pull/166/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 166`

View PR using the GUI difftool: \
`$ git pr show -t 166`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk24u/pull/166.diff">https://git.openjdk.org/jdk24u/pull/166.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk24u/pull/166#issuecomment-2764571542)
</details>
