### PR TITLE
Backport 67c4405250f93a1188c03bf336db160f77a10c7f

### DIFF
--- a/test/hotspot/jtreg/compiler/arguments/TestLogJIT.java
+++ b/test/hotspot/jtreg/compiler/arguments/TestLogJIT.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @summary Test running with log:jit*=debug enabled.
- * @run main/othervm -Xlog:jit*=debug compiler.arguments.TestTraceTypeProfile
+ * @run main/othervm -Xlog:jit*=debug compiler.arguments.TestLogJIT
  */
 
 package compiler.arguments;

--- a/test/hotspot/jtreg/compiler/c2/Test7005594.java
+++ b/test/hotspot/jtreg/compiler/c2/Test7005594.java
@@ -27,8 +27,8 @@
  * @summary Array overflow not handled correctly with loop optimzations
  *
  * @run main/othervm -Xcomp
-                     -XX:CompileOnly=compiler.c2.Test7005594::test
-                     compiler.c2.Test7005594
+ *                   -XX:CompileOnly=compiler.c2.Test7005594::test
+ *                   compiler.c2.Test7005594
  */
 
 package compiler.c2;

--- a/test/hotspot/jtreg/compiler/loopopts/TestMissingSkeletonPredicateForIfNode.java
+++ b/test/hotspot/jtreg/compiler/loopopts/TestMissingSkeletonPredicateForIfNode.java
@@ -28,7 +28,7 @@
  *          predicate is created in loop predication.
  * @requires vm.debug == true & vm.compiler2.enabled
  * @run main/othervm -XX:-TieredCompilation -Xbatch -XX:-RangeCheckElimination -XX:+BailoutToInterpreterForThrows
-                     compiler.loopopts.TestMissingSkeletonPredicateForIfNode
+ *                   compiler.loopopts.TestMissingSkeletonPredicateForIfNode
  */
 package compiler.loopopts;
 

--- a/test/hotspot/jtreg/compiler/loopopts/superword/TestSearchAlignment.java
+++ b/test/hotspot/jtreg/compiler/loopopts/superword/TestSearchAlignment.java
@@ -27,7 +27,7 @@
  * @summary JVM crash in SWPointer during C2 compilation
  *
  * @run main/othervm -XX:-TieredCompilation -XX:-BackgroundCompilation -XX:-UseOnStackReplacement
-        -XX:CompileCommand=compileonly,compiler.loopopts.superword.TestSearchAlignment::vMeth
+ *      -XX:CompileCommand=compileonly,compiler.loopopts.superword.TestSearchAlignment::vMeth
  *      compiler.loopopts.superword.TestSearchAlignment
  */
 


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [67c44052](https://github.com/openjdk/jdk/commit/67c4405250f93a1188c03bf336db160f77a10c7f) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Tobias Hartmann on 25 Mar 2025 and was reviewed by Roberto Castañeda Lozano and Christian Hagedorn.

Thanks!