### PR TITLE
8352879: TestPeriod.java and TestGetContentType.java run wrong test class

### DIFF
--- a/test/jdk/jdk/jfr/api/metadata/annotations/TestPeriod.java
+++ b/test/jdk/jdk/jfr/api/metadata/annotations/TestPeriod.java
@@ -26,6 +26,7 @@ package jdk.jfr.api.metadata.annotations;
 import jdk.jfr.Event;
 import jdk.jfr.EventType;
 import jdk.jfr.Period;
+import jdk.jfr.FlightRecorder;
 import jdk.test.lib.Asserts;
 import jdk.test.lib.jfr.Events;
 
@@ -44,6 +45,7 @@ public class TestPeriod {
 
     public static void main(String[] args) throws Exception {
         EventType periodicEvent = EventType.getEventType(PeriodicEvent.class);
+        FlightRecorder.addPeriodicEvent(PeriodicEvent.class, () -> {});
         String defaultValue = Events.getSetting(periodicEvent, Period.NAME).getDefaultValue();
         Asserts.assertEQ(defaultValue, "47 s", "Incorrect default value for period");
     }

--- a/test/jdk/jdk/jfr/api/metadata/annotations/TestPeriod.java
+++ b/test/jdk/jdk/jfr/api/metadata/annotations/TestPeriod.java
@@ -34,7 +34,7 @@ import jdk.test.lib.jfr.Events;
  * @key jfr
  * @requires vm.hasJFR
  * @library /test/lib
- * @run main/othervm jdk.jfr.api.metadata.annotations.TestLabel
+ * @run main/othervm jdk.jfr.api.metadata.annotations.TestPeriod
  */
 public class TestPeriod {
 

--- a/test/jdk/jdk/jfr/api/metadata/settingdescriptor/TestGetContentType.java
+++ b/test/jdk/jdk/jfr/api/metadata/settingdescriptor/TestGetContentType.java
@@ -38,7 +38,7 @@ import jdk.test.lib.jfr.Events;
  * @key jfr
  * @requires vm.hasJFR
  * @library /test/lib /test/jdk
- * @run main/othervm jdk.jfr.api.metadata.settingdescriptor.TestGetDescription
+ * @run main/othervm jdk.jfr.api.metadata.settingdescriptor.TestGetContentType
  */
 public class TestGetContentType {
 
@@ -49,7 +49,7 @@ public class TestGetContentType {
         Asserts.assertNull(plain.getContentType());
 
         SettingDescriptor annotatedType = Events.getSetting(type, "annotatedType");
-        Asserts.assertNull(annotatedType.getContentType(), Timestamp.class.getName());
+        Asserts.assertEquals(annotatedType.getContentType(), Timestamp.class.getName());
 
         SettingDescriptor newName = Events.getSetting(type, "newName");
         Asserts.assertEquals(newName.getContentType(), Timespan.class.getName());
@@ -58,7 +58,7 @@ public class TestGetContentType {
         Asserts.assertNull(overridden.getContentType());
 
         SettingDescriptor protectedBase = Events.getSetting(type, "protectedBase");
-        Asserts.assertEquals(protectedBase.getContentType(), Frequency.class);
+        Asserts.assertEquals(protectedBase.getContentType(), Frequency.class.getName());
 
         SettingDescriptor publicBase = Events.getSetting(type, "publicBase");
         Asserts.assertEquals(publicBase.getContentType(), Timestamp.class.getName());


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [b7ca76ef](https://github.com/openjdk/jdk/commit/b7ca76ef4bfc640668492e655acc6d755411a92f) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by SendaoYan on 1 Apr 2025 and was reviewed by Erik Gahlin.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [ ] [JDK-8353235](https://bugs.openjdk.org/browse/JDK-8353235) needs maintainer approval
- [x] Commit message must refer to an issue
- [ ] [JDK-8352879](https://bugs.openjdk.org/browse/JDK-8352879) needs maintainer approval

### Issues
 * [JDK-8352879](https://bugs.openjdk.org/browse/JDK-8352879): TestPeriod.java and TestGetContentType.java run wrong test class (**Bug** - P4)
 * [JDK-8353235](https://bugs.openjdk.org/browse/JDK-8353235): Test jdk/jfr/api/metadata/annotations/TestPeriod.java fails with IllegalArgumentException (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk24u.git pull/169/head:pull/169` \
`$ git checkout pull/169`

Update a local copy of the PR: \
`$ git checkout pull/169` \
`$ git pull https://git.openjdk.org/jdk24u.git pull/169/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 169`

View PR using the GUI difftool: \
`$ git pr show -t 169`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk24u/pull/169.diff">https://git.openjdk.org/jdk24u/pull/169.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk24u/pull/169#issuecomment-2768364276)
</details>
