### PR TITLE
8304674: File java.c compile error with -fsanitize=address -O0

### DIFF
--- a/src/java.base/share/native/libjli/java.c
+++ b/src/java.base/share/native/libjli/java.c
@@ -666,7 +666,14 @@ JavaMain(void* _args)
         ret = 1;
     }
     LEAVE();
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wreturn-type"
+#endif
 }
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
 
 /*
  * Test if the given name is one of the class path options.


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [9076673d](https://github.com/openjdk/jdk/commit/9076673d7df3c20bdb6e7fdf253030bc19a3d9dc) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by SendaoYan on 2 Apr 2025 and was reviewed by Magnus Ihse Bursie and Julian Waters.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] [JDK-8304674](https://bugs.openjdk.org/browse/JDK-8304674) needs maintainer approval

### Issue
 * [JDK-8304674](https://bugs.openjdk.org/browse/JDK-8304674): File java.c compile error with -fsanitize=address -O0 (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk24u.git pull/173/head:pull/173` \
`$ git checkout pull/173`

Update a local copy of the PR: \
`$ git checkout pull/173` \
`$ git pull https://git.openjdk.org/jdk24u.git pull/173/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 173`

View PR using the GUI difftool: \
`$ git pr show -t 173`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk24u/pull/173.diff">https://git.openjdk.org/jdk24u/pull/173.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk24u/pull/173#issuecomment-2772047220)
</details>
