### PR TITLE
8330936: [ubsan] exclude function BilinearInterp and ShapeSINextSpan in libawt java2d from ubsan checks

### DIFF
--- a/src/java.desktop/share/native/libawt/java2d/loops/TransformHelper.c
+++ b/src/java.desktop/share/native/libawt/java2d/loops/TransformHelper.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,6 +32,8 @@
 
 #include "sun_java2d_loops_TransformHelper.h"
 #include "java_awt_image_AffineTransformOp.h"
+
+#include "ub.h"
 
 /*
  * The stub functions replace the bilinear and bicubic interpolation
@@ -661,6 +663,7 @@ Transform_SafeHelper(JNIEnv *env,
         ((jubyte *)pRes)[comp] = (jubyte) ((cR + (1<<15)) >> 16); \
     } while (0)
 
+ATTRIBUTE_NO_UBSAN
 static void
 BilinearInterp(jint *pRGB, jint numpix,
                jint xfract, jint dxfract,

--- a/src/java.desktop/share/native/libawt/java2d/pipe/ShapeSpanIterator.c
+++ b/src/java.desktop/share/native/libawt/java2d/pipe/ShapeSpanIterator.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,6 +38,8 @@
 
 #include "sun_java2d_pipe_ShapeSpanIterator.h"
 #include "java_awt_geom_PathIterator.h"
+
+#include "ub.h"
 
 /*
  * This structure holds all of the information needed to trace and
@@ -1233,6 +1235,7 @@ ShapeSIIntersectClipBox(JNIEnv *env, void *private,
     }
 }
 
+ATTRIBUTE_NO_UBSAN
 static jboolean
 ShapeSINextSpan(void *state, jint spanbox[])
 {


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8330936](https://bugs.openjdk.org/browse/JDK-8330936) needs maintainer approval

### Issue
 * [JDK-8330936](https://bugs.openjdk.org/browse/JDK-8330936): [ubsan] exclude function BilinearInterp and ShapeSINextSpan in libawt java2d from ubsan checks (**Sub-task** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk24u.git pull/176/head:pull/176` \
`$ git checkout pull/176`

Update a local copy of the PR: \
`$ git checkout pull/176` \
`$ git pull https://git.openjdk.org/jdk24u.git pull/176/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 176`

View PR using the GUI difftool: \
`$ git pr show -t 176`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk24u/pull/176.diff">https://git.openjdk.org/jdk24u/pull/176.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk24u/pull/176#issuecomment-2772915540)
</details>
