### PR TITLE
8353709: Debug symbols bundle should contain full debug files when building --with-external-symbols-in-bundles=public

### DIFF
--- a/make/Bundles.gmk
+++ b/make/Bundles.gmk
@@ -245,7 +245,10 @@ ifneq ($(filter product-bundles% legacy-bundles, $(MAKECMDGOALS)), )
       )
 
   JDK_SYMBOLS_BUNDLE_FILES := \
-      $(call FindFiles, $(SYMBOLS_IMAGE_DIR))
+      $(filter-out \
+          %.stripped.pdb, \
+          $(call FindFiles, $(SYMBOLS_IMAGE_DIR)) \
+      )
 
   TEST_DEMOS_BUNDLE_FILES := $(filter $(JDK_DEMOS_IMAGE_HOMEDIR)/demo/%, \
       $(ALL_JDK_DEMOS_FILES))


### PR DESCRIPTION
Hi all,

This pull request contains a backport of [JDK-8353709](https://bugs.openjdk.org/browse/JDK-8353709), commit [60fbf73f](https://github.com/openjdk/jdk/commit/60fbf73fc492ad9fff83fb4540e2d01311406287) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Christoph Langer on 7 Apr 2025 and was reviewed by Erik Joelsson and Matthias Baesken.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8353709](https://bugs.openjdk.org/browse/JDK-8353709) needs maintainer approval

### Issue
 * [JDK-8353709](https://bugs.openjdk.org/browse/JDK-8353709): Debug symbols bundle should contain full debug files when building --with-external-symbols-in-bundles=public (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk24u.git pull/185/head:pull/185` \
`$ git checkout pull/185`

Update a local copy of the PR: \
`$ git checkout pull/185` \
`$ git pull https://git.openjdk.org/jdk24u.git pull/185/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 185`

View PR using the GUI difftool: \
`$ git pr show -t 185`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk24u/pull/185.diff">https://git.openjdk.org/jdk24u/pull/185.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk24u/pull/185#issuecomment-2783525315)
</details>
