### PR TITLE
8344892: beans/finder/MethodFinder.findMethod incorrectly returns null

### DIFF
--- a/src/java.desktop/share/classes/com/sun/beans/finder/MethodFinder.java
+++ b/src/java.desktop/share/classes/com/sun/beans/finder/MethodFinder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -77,8 +77,7 @@ public final class MethodFinder extends AbstractFinder<Method> {
         Signature signature = new Signature(type, name, args);
 
         try {
-            Method method = CACHE.get(signature);
-            return (method == null) ? method : CACHE.create(signature);
+            return CACHE.get(signature);
         }
         catch (SignatureException exception) {
             throw exception.toNoSuchMethodException("Method '" + name + "' is not found");


### PR DESCRIPTION
Hi all,

This pull request contains a backport of [JDK-8344892](https://bugs.openjdk.org/browse/JDK-8344892), commit [216f113f](https://github.com/openjdk/jdk/commit/216f113f8b377054bcfccf875ab29e967164d8ab) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Alexander Zvegintsev on 4 Mar 2025 and was reviewed by Alexey Ivanov and Sergey Bylokhov.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8344892](https://bugs.openjdk.org/browse/JDK-8344892) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8344892](https://bugs.openjdk.org/browse/JDK-8344892): beans/finder/MethodFinder.findMethod incorrectly returns null (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk24u.git pull/189/head:pull/189` \
`$ git checkout pull/189`

Update a local copy of the PR: \
`$ git checkout pull/189` \
`$ git pull https://git.openjdk.org/jdk24u.git pull/189/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 189`

View PR using the GUI difftool: \
`$ git pr show -t 189`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk24u/pull/189.diff">https://git.openjdk.org/jdk24u/pull/189.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk24u/pull/189#issuecomment-2801655057)
</details>
