### PR TITLE
8353329: Small memory leak when create GrowableArray with initial size 0

### DIFF
--- a/src/hotspot/share/utilities/growableArray.cpp
+++ b/src/hotspot/share/utilities/growableArray.cpp
@@ -44,6 +44,11 @@ void* GrowableArrayArenaAllocator::allocate(int max, int element_size, Arena* ar
 
 void* GrowableArrayCHeapAllocator::allocate(int max, int element_size, MemTag mem_tag) {
   assert(max >= 0, "integer overflow");
+
+  if (max == 0) {
+    return nullptr;
+  }
+
   size_t byte_size = element_size * (size_t) max;
 
   // memory tag has to be specified for C heap allocation

--- a/src/hotspot/share/utilities/growableArray.hpp
+++ b/src/hotspot/share/utilities/growableArray.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -811,10 +811,6 @@ class GrowableArrayCHeap : public GrowableArrayWithAllocator<E, GrowableArrayCHe
   STATIC_ASSERT(MT != mtNone);
 
   static E* allocate(int max, MemTag mem_tag) {
-    if (max == 0) {
-      return nullptr;
-    }
-
     return (E*)GrowableArrayCHeapAllocator::allocate(max, sizeof(E), mem_tag);
   }
 


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [b80b04d7](https://github.com/openjdk/jdk/commit/b80b04d77afdb2a808e2c7f9268d8092eb16714e) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Zhengyu Gu on 2 Apr 2025 and was reviewed by Johan Sjölen and Stefan Karlsson.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8353329](https://bugs.openjdk.org/browse/JDK-8353329) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8353329](https://bugs.openjdk.org/browse/JDK-8353329): Small memory leak when create GrowableArray with initial size 0 (**Bug** - P4 - Approved)


### Reviewers
 * [Zhengyu Gu](https://openjdk.org/census#zgu) (@zhengyu123 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk24u.git pull/192/head:pull/192` \
`$ git checkout pull/192`

Update a local copy of the PR: \
`$ git checkout pull/192` \
`$ git pull https://git.openjdk.org/jdk24u.git pull/192/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 192`

View PR using the GUI difftool: \
`$ git pr show -t 192`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk24u/pull/192.diff">https://git.openjdk.org/jdk24u/pull/192.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk24u/pull/192#issuecomment-2803635291)
</details>
