### PR TITLE
8350854: Include thread counts in safepoint logging

### DIFF
--- a/src/hotspot/share/runtime/safepoint.cpp
+++ b/src/hotspot/share/runtime/safepoint.cpp
@@ -993,13 +993,16 @@ void SafepointTracing::end() {
      "Reaching safepoint: " JLONG_FORMAT " ns, "
      "At safepoint: " JLONG_FORMAT " ns, "
      "Leaving safepoint: " JLONG_FORMAT " ns, "
-     "Total: " JLONG_FORMAT " ns",
+     "Total: " JLONG_FORMAT " ns, "
+     "Threads: %d runnable, %d total",
       VM_Operation::name(_current_type),
       _last_app_time_ns,
       _last_safepoint_sync_time_ns  - _last_safepoint_begin_time_ns,
       _last_safepoint_leave_time_ns - _last_safepoint_sync_time_ns,
       _last_safepoint_end_time_ns   - _last_safepoint_leave_time_ns,
-      _last_safepoint_end_time_ns   - _last_safepoint_begin_time_ns
+      _last_safepoint_end_time_ns   - _last_safepoint_begin_time_ns,
+      _nof_running,
+      _nof_threads
      );
 
   RuntimeService::record_safepoint_end(_last_safepoint_end_time_ns - _last_safepoint_sync_time_ns);


### PR DESCRIPTION
Hi all,

This pull request contains a clean backport of commit [61d9ab97](https://github.com/openjdk/jdk/commit/61d9ab9717783e5bb0faa555f794499d0e5b3fdb) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Xiaolong Peng on 5 Mar 2025 and was reviewed by Aleksey Shipilev and David Holmes.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] [JDK-8350854](https://bugs.openjdk.org/browse/JDK-8350854) needs maintainer approval

### Issue
 * [JDK-8350854](https://bugs.openjdk.org/browse/JDK-8350854): Include thread counts in safepoint logging (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk24u.git pull/202/head:pull/202` \
`$ git checkout pull/202`

Update a local copy of the PR: \
`$ git checkout pull/202` \
`$ git pull https://git.openjdk.org/jdk24u.git pull/202/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 202`

View PR using the GUI difftool: \
`$ git pr show -t 202`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk24u/pull/202.diff">https://git.openjdk.org/jdk24u/pull/202.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk24u/pull/202#issuecomment-2817478549)
</details>
