### PR TITLE
8349705: java.net.URI.scanIPv4Address throws unnecessary URISyntaxException

### DIFF
--- a/src/java.base/share/classes/java/net/URI.java
+++ b/src/java.base/share/classes/java/net/URI.java
@@ -3466,7 +3466,7 @@ public final class URI
                 if (q < m) break;
                 return q;
             }
-            fail("Malformed IPv4 address", q);
+            if (strict) fail("Malformed IPv4 address", q);
             return -1;
         }
 
@@ -3495,12 +3495,16 @@ public final class URI
                 return -1;
             }
 
+            if (p == -1) {
+                return p;
+            }
+
             if (p > start && p < n) {
                 // IPv4 address is followed by something - check that
                 // it's a ":" as this is the only valid character to
                 // follow an address.
                 if (input.charAt(p) != ':') {
-                    p = -1;
+                    return -1;
                 }
             }
 


### PR DESCRIPTION
Hi all,

This pull request contains a clean backport of commit [a90f323d](https://github.com/openjdk/jdk/commit/a90f323d05f1c90767823b8729b124de0bead265) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Xiaolong Peng on 8 Mar 2025 and was reviewed by Daniel Fuchs.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] [JDK-8349705](https://bugs.openjdk.org/browse/JDK-8349705) needs maintainer approval

### Issue
 * [JDK-8349705](https://bugs.openjdk.org/browse/JDK-8349705): java.net.URI.scanIPv4Address throws unnecessary URISyntaxException (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk24u.git pull/203/head:pull/203` \
`$ git checkout pull/203`

Update a local copy of the PR: \
`$ git checkout pull/203` \
`$ git pull https://git.openjdk.org/jdk24u.git pull/203/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 203`

View PR using the GUI difftool: \
`$ git pr show -t 203`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk24u/pull/203.diff">https://git.openjdk.org/jdk24u/pull/203.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk24u/pull/203#issuecomment-2818980242)
</details>
