### PR TITLE
8355524: Only every second line in upgradeable files is being used

### DIFF
--- a/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/LinkableRuntimeImage.java
+++ b/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/LinkableRuntimeImage.java
@@ -93,7 +93,7 @@ public class LinkableRuntimeImage {
                     // Skip comments
                     continue;
                 }
-                upgradeableFiles.add(scanner.nextLine());
+                upgradeableFiles.add(line);
             }
         } catch (IOException e) {
             throw new AssertionError("Failure to retrieve upgradeable files for " +

--- a/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/runtimelink/upgrade_files_java.base.conf
+++ b/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/runtimelink/upgrade_files_java.base.conf
@@ -1,4 +1,4 @@
 # Configuration for resource paths of files allowed to be
 # upgraded (in java.base)
-lib/tzdb.dat
 lib/security/cacerts
+lib/tzdb.dat


### PR DESCRIPTION
This is a fix-up for the change in 24.0.2 added with [JDK-8353185](https://bugs.openjdk.org/browse/JDK-8353185). Clean, low-risk patch only affecting run-time linking and systems which need the upgradeable files handling.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8355524](https://bugs.openjdk.org/browse/JDK-8355524) needs maintainer approval

### Issue
 * [JDK-8355524](https://bugs.openjdk.org/browse/JDK-8355524): Only every second line in upgradeable files is being used (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk24u.git pull/207/head:pull/207` \
`$ git checkout pull/207`

Update a local copy of the PR: \
`$ git checkout pull/207` \
`$ git pull https://git.openjdk.org/jdk24u.git pull/207/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 207`

View PR using the GUI difftool: \
`$ git pr show -t 207`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk24u/pull/207.diff">https://git.openjdk.org/jdk24u/pull/207.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk24u/pull/207#issuecomment-2829940782)
</details>
