### PR TITLE
8355498: [AIX] Adapt code for C++ VLA rule

### DIFF
--- a/src/hotspot/os/aix/os_perf_aix.cpp
+++ b/src/hotspot/os/aix/os_perf_aix.cpp
@@ -73,7 +73,7 @@ enum {
  * Get info for requested PID from /proc/<pid>/psinfo file
  */
 static bool read_psinfo(const u_longlong_t& pid, psinfo_t& psinfo) {
-  static size_t BUF_LENGTH = 32 + sizeof(u_longlong_t);
+  const size_t BUF_LENGTH = 32 + sizeof(u_longlong_t);
 
   FILE* fp;
   char buf[BUF_LENGTH];


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [2447b981](https://github.com/openjdk/jdk/commit/2447b9812a9f7316a2313f70db4974534fceb9d9) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Suchismith Roy on 28 Apr 2025 and was reviewed by Joachim Kern and Martin Doerr.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] [JDK-8355498](https://bugs.openjdk.org/browse/JDK-8355498) needs maintainer approval

### Issue
 * [JDK-8355498](https://bugs.openjdk.org/browse/JDK-8355498): [AIX] Adapt code for C++ VLA rule (**Bug** - P4 - Requested)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk24u.git pull/214/head:pull/214` \
`$ git checkout pull/214`

Update a local copy of the PR: \
`$ git checkout pull/214` \
`$ git pull https://git.openjdk.org/jdk24u.git pull/214/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 214`

View PR using the GUI difftool: \
`$ git pr show -t 214`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk24u/pull/214.diff">https://git.openjdk.org/jdk24u/pull/214.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk24u/pull/214#issuecomment-2855134860)
</details>
