### PR TITLE
8354255: [jittester] Remove TempDir debug output

### DIFF
--- a/test/hotspot/jtreg/testlibrary/jittester/src/jdk/test/lib/jittester/TempDir.java
+++ b/test/hotspot/jtreg/testlibrary/jittester/src/jdk/test/lib/jittester/TempDir.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -47,14 +47,11 @@ public class TempDir {
         } catch (IOException e) {
             throw new Error("Can't create a tmp dir for " + suffix, e);
         }
-
-        System.out.println("DBG: Temp folder created: '" + path + "'");
     }
 
     private void delete() {
         try {
             FileUtils.deleteFileTreeWithRetry(path);
-            System.out.println("DBG: Temp folder deleted: '" + path + "'");
         } catch (IOException exc) {
             throw new Error("Could not deep delete '" + path + "'", exc);
         }


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [1fc1cc5d](https://github.com/openjdk/jdk/commit/1fc1cc5da9a38cf936636a72f9b8a4c246ceaab4) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Evgeny Nikitin on 11 Apr 2025 and was reviewed by Christian Hagedorn and Tobias Hartmann.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] [JDK-8354255](https://bugs.openjdk.org/browse/JDK-8354255) needs maintainer approval

### Issue
 * [JDK-8354255](https://bugs.openjdk.org/browse/JDK-8354255): [jittester] Remove TempDir debug output (**Bug** - P4 - Requested)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk24u.git pull/218/head:pull/218` \
`$ git checkout pull/218`

Update a local copy of the PR: \
`$ git checkout pull/218` \
`$ git pull https://git.openjdk.org/jdk24u.git pull/218/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 218`

View PR using the GUI difftool: \
`$ git pr show -t 218`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk24u/pull/218.diff">https://git.openjdk.org/jdk24u/pull/218.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk24u/pull/218#issuecomment-2866056827)
</details>
