### PR TITLE
8356571: Re-enable -Wtype-limits for GCC in LCMS

### DIFF
--- a/make/modules/java.desktop/lib/ClientLibraries.gmk
+++ b/make/modules/java.desktop/lib/ClientLibraries.gmk
@@ -85,7 +85,7 @@ $(eval $(call SetupJdkLibrary, BUILD_LIBLCMS, \
         libawt/java2d \
         java.base:libjvm, \
     HEADERS_FROM_SRC := $(LIBLCMS_HEADERS_FROM_SRC), \
-    DISABLED_WARNINGS_gcc := format-nonliteral stringop-truncation type-limits \
+    DISABLED_WARNINGS_gcc := format-nonliteral stringop-truncation \
         unused-variable, \
     DISABLED_WARNINGS_clang := format-nonliteral, \
     JDK_LIBS := libawt java.base:libjava, \


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [9a0e6f33](https://github.com/openjdk/jdk/commit/9a0e6f338f34fb5da16d5f9eb710cdddd4302945) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Sergey Bylokhov on 9 May 2025 and was reviewed by Julian Waters and Phil Race.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] [JDK-8356571](https://bugs.openjdk.org/browse/JDK-8356571) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8356571](https://bugs.openjdk.org/browse/JDK-8356571): Re-enable -Wtype-limits for GCC in LCMS (**Bug** - P4 - Requested)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk24u.git pull/221/head:pull/221` \
`$ git checkout pull/221`

Update a local copy of the PR: \
`$ git checkout pull/221` \
`$ git pull https://git.openjdk.org/jdk24u.git pull/221/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 221`

View PR using the GUI difftool: \
`$ git pr show -t 221`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk24u/pull/221.diff">https://git.openjdk.org/jdk24u/pull/221.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk24u/pull/221#issuecomment-2874663235)
</details>
