### PR TITLE
8357173: Split jtreg test group jdk tier3

### DIFF
--- a/test/jdk/TEST.groups
+++ b/test/jdk/TEST.groups
@@ -1,4 +1,4 @@
-#  Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
+#  Copyright (c) 2013, 2025, Oracle and/or its affiliates. All rights reserved.
 #  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 #  This code is free software; you can redistribute it and/or modify it
@@ -83,7 +83,14 @@ tier2_part2 = \
 tier2_part3 = \
     :jdk_net
 
+# These sub groups of tier3 allow for running certain tests separately from the
+# rest. When adding tests to tier3, in most cases they should be added to
+# tier3_part1.
 tier3 = \
+    :tier3_part1 \
+    :tier3_jpackage
+
+tier3_part1 = \
     :build \
     :jdk_vector \
     -:jdk_vector_sanity \
@@ -91,8 +98,11 @@ tier3 = \
     :jdk_svc \
     -:jdk_svc_sanity \
     -:svc_tools \
-    :jdk_jpackage \
     :jdk_since_checks
+
+# The jpackage tests on Windows require permissions that aren't always present
+tier3_jpackage = \
+    :jdk_jpackage
 
 # Everything not in other tiers
 tier4 = \


### PR DESCRIPTION
Clean backport of this change. 

We need to be able to run the jdk_jpackage tests separately from the rest of jdk tier3 due to different requirements on the test environment. To achieve this we would like to introduce tier3_part1 and tier3_jpackage groups as sub groups to tier3.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] [JDK-8357173](https://bugs.openjdk.org/browse/JDK-8357173) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8357173](https://bugs.openjdk.org/browse/JDK-8357173): Split jtreg test group jdk tier3 (**Bug** - P2)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk24u.git pull/226/head:pull/226` \
`$ git checkout pull/226`

Update a local copy of the PR: \
`$ git checkout pull/226` \
`$ git pull https://git.openjdk.org/jdk24u.git pull/226/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 226`

View PR using the GUI difftool: \
`$ git pr show -t 226`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk24u/pull/226.diff">https://git.openjdk.org/jdk24u/pull/226.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk24u/pull/226#issuecomment-2913975073)
</details>
