### PR TITLE
8357550: GenShen crashes during freeze: assert(!chunk->requires_barriers()) failed

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahGenerationalHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGenerationalHeap.cpp
@@ -184,6 +184,29 @@ void ShenandoahGenerationalHeap::stop() {
   regulator_thread()->stop();
 }
 
+bool ShenandoahGenerationalHeap::requires_barriers(stackChunkOop obj) const {
+  if (is_idle()) {
+    return false;
+  }
+
+  if (is_concurrent_young_mark_in_progress() && is_in_young(obj) && !marking_context()->allocated_after_mark_start(obj)) {
+    // We are marking young, this object is in young, and it is below the TAMS
+    return true;
+  }
+
+  if (is_in_old(obj)) {
+    // Card marking barriers are required for objects in the old generation
+    return true;
+  }
+
+  if (has_forwarded_objects()) {
+    // Object may have pointers that need to be updated
+    return true;
+  }
+
+  return false;
+}
+
 void ShenandoahGenerationalHeap::evacuate_collection_set(bool concurrent) {
   ShenandoahRegionIterator regions;
   ShenandoahGenerationalEvacuationTask task(this, &regions, concurrent, false /* only promote regions */);

--- a/src/hotspot/share/gc/shenandoah/shenandoahGenerationalHeap.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGenerationalHeap.hpp
@@ -128,6 +128,8 @@ public:
 
   void stop() override;
 
+  bool requires_barriers(stackChunkOop obj) const override;
+
   // Used for logging the result of a region transfer outside the heap lock
   struct TransferResult {
     bool success;


### PR DESCRIPTION
This is a low risk change that fixes an assertion failure with Shenandoah's generational mode and virtual threads. Only Shenandoah's generational mode is affected by this change.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] [JDK-8357550](https://bugs.openjdk.org/browse/JDK-8357550) needs maintainer approval

### Issue
 * [JDK-8357550](https://bugs.openjdk.org/browse/JDK-8357550): GenShen crashes during freeze: assert(!chunk-&gt;requires_barriers()) failed (**Bug** - P3 - Requested)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk24u.git pull/234/head:pull/234` \
`$ git checkout pull/234`

Update a local copy of the PR: \
`$ git checkout pull/234` \
`$ git pull https://git.openjdk.org/jdk24u.git pull/234/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 234`

View PR using the GUI difftool: \
`$ git pr show -t 234`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk24u/pull/234.diff">https://git.openjdk.org/jdk24u/pull/234.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk24u/pull/234#issuecomment-2992835342)
</details>
