### PR TITLE
8352896: LambdaExpr02.java runs wrong test class

### DIFF
--- a/test/langtools/tools/javac/lambda/LambdaExpr02.java
+++ b/test/langtools/tools/javac/lambda/LambdaExpr02.java
@@ -28,7 +28,7 @@
  *  basic test for simple lambda expressions in multiple scopes
  * @author  Brian Goetz
  * @author  Maurizio Cimadamore
- * @run main LambdaExpr01
+ * @run main LambdaExpr02
  */
 
 public class LambdaExpr02 {


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [c0292203](https://github.com/openjdk/jdk/commit/c0292203794bf3a8bfb02eac062e226ef2d07ee1) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Zihao Lin on 28 Mar 2025 and was reviewed by Aleksey Shipilev and Jan Lahoda.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] [JDK-8352896](https://bugs.openjdk.org/browse/JDK-8352896) needs maintainer approval

### Issue
 * [JDK-8352896](https://bugs.openjdk.org/browse/JDK-8352896): LambdaExpr02.java runs wrong test class (**Bug** - P4 - Requested)


### Reviewers
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - no project role)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk24u.git pull/235/head:pull/235` \
`$ git checkout pull/235`

Update a local copy of the PR: \
`$ git checkout pull/235` \
`$ git pull https://git.openjdk.org/jdk24u.git pull/235/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 235`

View PR using the GUI difftool: \
`$ git pr show -t 235`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk24u/pull/235.diff">https://git.openjdk.org/jdk24u/pull/235.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk24u/pull/235#issuecomment-2995305557)
</details>
