### PR TITLE
8347712: IllegalStateException on multithreaded ZipFile access with non-UTF8 charset

### DIFF
--- a/src/java.base/share/classes/java/util/zip/ZipCoder.java
+++ b/src/java.base/share/classes/java/util/zip/ZipCoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,7 +38,10 @@ import jdk.internal.util.ArraysSupport;
 import sun.nio.cs.UTF_8;
 
 /**
- * Utility class for ZIP file entry name and comment decoding and encoding
+ * Utility class for ZIP file entry name and comment decoding and encoding.
+ * <p>
+ * The {@code ZipCoder} for UTF-8 charset is thread safe, {@code ZipCoder}
+ * for other charsets require external synchronization.
  */
 class ZipCoder {
 
@@ -172,6 +175,13 @@ class ZipCoder {
               .onUnmappableCharacter(CodingErrorAction.REPORT);
         }
         return dec;
+    }
+
+    /**
+     * {@return the {@link Charset} used by this {@code ZipCoder}}
+     */
+    final Charset charset() {
+        return this.cs;
     }
 
     private CharsetEncoder encoder() {

--- a/test/jdk/java/util/zip/ZipFile/ZipFileCharsetTest.java
+++ b/test/jdk/java/util/zip/ZipFile/ZipFileCharsetTest.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
+import java.util.zip.ZipOutputStream;
+
+import org.junit.jupiter.api.Test;
+import static java.nio.charset.StandardCharsets.ISO_8859_1;
+import static java.nio.charset.StandardCharsets.US_ASCII;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+/*
+ * @test
+ * @bug 8355975
+ * @summary verify that the internal ZIP structure caching in java.util.zip.ZipFile
+ *          uses the correct Charset when parsing the ZIP structure of a ZIP file
+ * @run junit ZipFileCharsetTest
+ */
+public class ZipFileCharsetTest {
+
+    private static final String ISO_8859_15_NAME = "ISO-8859-15";
+
+    /**
+     * The internal implementation of java.util.zip.ZipFile maintains a cache
+     * of the ZIP structure of each ZIP file that's currently open. This cache
+     * helps prevent repeat parsing of the ZIP structure of the same underlying
+     * ZIP file, every time a ZipFile instance is created for the same ZIP file.
+     * The cache uses an internal key to map a ZIP file to the corresponding
+     * ZIP structure that's cached.
+     * A ZipFile can be constructed by passing a Charset which will be used to
+     * decode the entry names (and comment) in a ZIP file.
+     * The test verifies that when multiple ZipFile instances are
+     * constructed using different Charsets but the same underlying ZIP file,
+     * then the internal caching implementation of ZipFile doesn't end up using
+     * a wrong Charset for parsing the ZIP structure of the ZIP file.
+     */
+    @Test
+    void testCachedZipFileSource() throws Exception {
+        // ISO-8859-15 is not a standard charset in Java. We skip this test
+        // when it is unavailable
+        assumeTrue(Charset.availableCharsets().containsKey(ISO_8859_15_NAME),
+                "skipping test since " + ISO_8859_15_NAME + " charset isn't available");
+
+        // We choose the byte 0xA4 for entry name in the ZIP file.
+        // 0xA4 is "Euro sign" in ISO-8859-15 charset and
+        // "Currency sign (generic)" in ISO-8859-1 charset.
+        final byte[] entryNameBytes = new byte[]{(byte) 0xA4}; // intentional cast
+        final Charset euroSignCharset = Charset.forName(ISO_8859_15_NAME);
+        final Charset currencySignCharset = ISO_8859_1;
+
+        final String euroSign = new String(entryNameBytes, euroSignCharset);
+        final String currencySign = new String(entryNameBytes, currencySignCharset);
+
+        // create a ZIP file whose entry name is encoded using ISO-8859-15 charset
+        final Path zip = createZIP("euro", euroSignCharset, entryNameBytes);
+
+        // Construct a ZipFile instance using the (incorrect) charset ISO-8859-1.
+        // While that ZipFile instance is still open (and the ZIP file structure
+        // still cached), construct another instance for the same ZIP file, using
+        // the (correct) charset ISO-8859-15.
+        try (ZipFile incorrect = new ZipFile(zip.toFile(), currencySignCharset);
+             ZipFile correct = new ZipFile(zip.toFile(), euroSignCharset)) {
+
+            // correct encoding should resolve the entry name to euro sign
+            // and the entry should be thus be located
+            assertNotNull(correct.getEntry(euroSign), "euro sign entry missing in " + correct);
+            // correct encoding should not be able to find an entry name
+            // with the currency sign
+            assertNull(correct.getEntry(currencySign), "currency sign entry unexpectedly found in "
+                    + correct);
+
+            // incorrect encoding should resolve the entry name to currency sign
+            // and the entry should be thus be located by the currency sign name
+            assertNotNull(incorrect.getEntry(currencySign), "currency sign entry missing in "
+                    + incorrect);
+            // incorrect encoding should not be able to find an entry name
+            // with the euro sign
+            assertNull(incorrect.getEntry(euroSign), "euro sign entry unexpectedly found in "
+                    + incorrect);
+        }
+    }
+
+    /**
+     * Creates and return ZIP file whose entry names are encoded using the given {@code charset}
+     */
+    private static Path createZIP(final String fileNamePrefix, final Charset charset,
+                                  final byte[] entryNameBytes) throws IOException {
+        final Path zip = Files.createTempFile(Path.of("."), fileNamePrefix, ".zip");
+        // create a ZIP file whose entry name(s) use the given charset
+        try (ZipOutputStream zos = new ZipOutputStream(Files.newOutputStream(zip), charset)) {
+            zos.putNextEntry(new ZipEntry(new String(entryNameBytes, charset)));
+            final byte[] entryContent = "doesnotmatter".getBytes(US_ASCII);
+            zos.write(entryContent);
+            zos.closeEntry();
+        }
+        return zip;
+    }
+}

--- a/test/jdk/java/util/zip/ZipFile/ZipFileSharedSourceTest.java
+++ b/test/jdk/java/util/zip/ZipFile/ZipFileSharedSourceTest.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.io.OutputStream;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
+import java.util.zip.ZipOutputStream;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import static java.nio.charset.StandardCharsets.US_ASCII;
+
+/*
+ * @test
+ * @bug 8347712
+ * @summary verify that different instances of java.util.zip.ZipFile do not share
+ *          the same instance of (non-thread-safe) java.nio.charset.CharsetEncoder/CharsetDecoder
+ * @run junit ZipFileSharedSourceTest
+ */
+public class ZipFileSharedSourceTest {
+
+    static Path createZipFile(final Charset charset) throws Exception {
+        final Path zipFilePath = Files.createTempFile(Path.of("."), "8347712", ".zip");
+        try (OutputStream os = Files.newOutputStream(zipFilePath);
+             ZipOutputStream zos = new ZipOutputStream(os, charset)) {
+            final int numEntries = 10240;
+            for (int i = 1; i <= numEntries; i++) {
+                final ZipEntry entry = new ZipEntry("entry-" + i);
+                zos.putNextEntry(entry);
+                zos.write("foo bar".getBytes(US_ASCII));
+                zos.closeEntry();
+            }
+        }
+        return zipFilePath;
+    }
+
+    static List<Arguments> charsets() {
+        return List.of(
+                Arguments.of(StandardCharsets.UTF_8),
+                Arguments.of(StandardCharsets.ISO_8859_1),
+                Arguments.of(US_ASCII)
+        );
+    }
+
+    /**
+     * In this test, multiple concurrent threads each create an instance of java.util.zip.ZipFile
+     * with the given {@code charset} for the same underlying ZIP file. Each of the threads
+     * then iterate over the entries of their ZipFile instance. The test verifies that such access,
+     * where each thread is accessing an independent ZipFile instance corresponding to the same
+     * underlying ZIP file, doesn't lead to unexpected failures contributed by concurrent
+     * threads.
+     */
+    @ParameterizedTest
+    @MethodSource("charsets")
+    void testMultipleZipFileInstances(final Charset charset) throws Exception {
+        final Path zipFilePath = createZipFile(charset);
+        final int numTasks = 200;
+        final CountDownLatch startLatch = new CountDownLatch(numTasks);
+        final List<Future<Void>> results = new ArrayList<>();
+        try (final ExecutorService executor =
+                     Executors.newThreadPerTaskExecutor(Thread.ofPlatform().factory())) {
+            for (int i = 0; i < numTasks; i++) {
+                final var task = new ZipEntryIteratingTask(zipFilePath, charset,
+                        startLatch);
+                results.add(executor.submit(task));
+            }
+            System.out.println(numTasks + " tasks submitted, waiting for them to complete");
+            for (final Future<Void> f : results) {
+                f.get();
+            }
+        }
+        System.out.println("All " + numTasks + " tasks completed successfully");
+    }
+
+    private static final class ZipEntryIteratingTask implements Callable<Void> {
+        private final Path file;
+        private final Charset charset;
+        private final CountDownLatch startLatch;
+
+        private ZipEntryIteratingTask(final Path file, final Charset charset,
+                                      final CountDownLatch startLatch) {
+            this.file = file;
+            this.charset = charset;
+            this.startLatch = startLatch;
+        }
+
+        @Override
+        public Void call() throws Exception {
+            // let other tasks know we are ready to run
+            this.startLatch.countDown();
+            // wait for other tasks to be ready to run
+            this.startLatch.await();
+            // create a new instance of ZipFile and iterate over the entries
+            try (final ZipFile zf = new ZipFile(this.file.toFile(), this.charset)) {
+                final var entries = zf.entries();
+                while (entries.hasMoreElements()) {
+                    final ZipEntry ze = entries.nextElement();
+                    // additionally exercise the ZipFile.getEntry() method
+                    zf.getEntry(ze.getName());
+                }
+            }
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
Multithreaded handling of ZIP files can throw an exception.

This is a clean backport.

This jdk24, [jdk21](https://github.com/openjdk/jdk21u-dev/pull/1949), [jdk17](https://github.com/openjdk/jdk17u-dev/pull/3720).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] [JDK-8347712](https://bugs.openjdk.org/browse/JDK-8347712) needs maintainer approval
- [ ] [JDK-8355975](https://bugs.openjdk.org/browse/JDK-8355975) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8347712](https://bugs.openjdk.org/browse/JDK-8347712): IllegalStateException on multithreaded ZipFile access with non-UTF8 charset (**Bug** - P3)
 * [JDK-8355975](https://bugs.openjdk.org/browse/JDK-8355975): ZipFile uses incorrect Charset if another instance for the same ZIP file was constructed with a different Charset (**Bug** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk24u.git pull/236/head:pull/236` \
`$ git checkout pull/236`

Update a local copy of the PR: \
`$ git checkout pull/236` \
`$ git pull https://git.openjdk.org/jdk24u.git pull/236/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 236`

View PR using the GUI difftool: \
`$ git pr show -t 236`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk24u/pull/236.diff">https://git.openjdk.org/jdk24u/pull/236.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk24u/pull/236#issuecomment-3048849014)
</details>
